### PR TITLE
Try improve regex performance

### DIFF
--- a/Assets/Nova/Sources/Core/ScriptParsing/ScriptDialogueEntryParser.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/ScriptDialogueEntryParser.cs
@@ -57,6 +57,11 @@ namespace Nova
 
         private static readonly List<ActionGenerator> ActionGenerators = new List<ActionGenerator>();
 
+        public static void ClearPatterns()
+        {
+            ActionGenerators.Clear();
+        }
+
         // Generate `preload(obj, 'resource')` when matching `func(obj, 'resource', ...)` or `...(func, obj, 'resource', ...)`
         // TODO: handle line break in patterns
         public static void AddPattern(string funcName)

--- a/Assets/Nova/Sources/Core/ScriptParsing/ScriptLoader.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/ScriptLoader.cs
@@ -62,14 +62,15 @@ namespace Nova
             }
         }
 
-        private List<LazyBindingEntry> lazyBindingLinks;
+        private readonly List<LazyBindingEntry> lazyBindingLinks = new List<LazyBindingEntry>();
 
-        private HashSet<string> onlyIncludedNames;
+        private readonly HashSet<string> onlyIncludedNames = new HashSet<string>();
 
         private void InitOnlyIncludedNames()
         {
             var table = LuaRuntime.Instance.GetTable("only_included_scenario_names");
-            onlyIncludedNames = new HashSet<string>(table.ToArray().Cast<string>());
+            onlyIncludedNames.Clear();
+            onlyIncludedNames.UnionWith(table.ToArray().Cast<string>());
             table.Dispose();
         }
 
@@ -77,7 +78,7 @@ namespace Nova
         {
             currentNode = null;
             stateLocale = I18n.DefaultLocale;
-            lazyBindingLinks = new List<LazyBindingEntry>();
+            lazyBindingLinks.Clear();
 
             ScriptDialogueEntryParser.ClearPatterns();
             // requires.lua is executed and ScriptDialogueEntryParser.ActionGenerators is filled before calling ParseScript()
@@ -264,7 +265,7 @@ namespace Nova
             }
 
             // Remove unnecessary reference
-            lazyBindingLinks = null;
+            lazyBindingLinks.Clear();
         }
 
         /// <summary>

--- a/Assets/Nova/Sources/Core/ScriptParsing/ScriptLoader.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/ScriptLoader.cs
@@ -79,7 +79,8 @@ namespace Nova
             stateLocale = I18n.DefaultLocale;
             lazyBindingLinks = new List<LazyBindingEntry>();
 
-            // requires.lua is executed and ScriptDialogueEntryParser.PatternToActionGenerator is filled before calling ParseScript()
+            ScriptDialogueEntryParser.ClearPatterns();
+            // requires.lua is executed and ScriptDialogueEntryParser.ActionGenerators is filled before calling ParseScript()
             LuaRuntime.Instance.BindObject("scriptLoader", this);
             LuaRuntime.Instance.UpdateExecutionContext(new ExecutionContext(ExecutionMode.Eager, DialogueActionStage.Default, false));
             InitOnlyIncludedNames();

--- a/Assets/Nova/Sources/Scripts/UI/InputMapping/CompoundKeyRecorder.cs
+++ b/Assets/Nova/Sources/Scripts/UI/InputMapping/CompoundKeyRecorder.cs
@@ -12,6 +12,8 @@ namespace Nova
 
     public class CompoundKeyRecorder : MonoBehaviour, IPointerClickHandler
     {
+        private static readonly Regex PathPattern = new Regex(@"^\/?[^\/]*\/", RegexOptions.Compiled);
+
         private static readonly Key[] AllowedKeys =
         {
             Key.A, Key.B, Key.C, Key.D, Key.E, Key.F, Key.G, Key.H, Key.I, Key.J, Key.K, Key.L, Key.M,
@@ -93,18 +95,17 @@ namespace Nova
         private static string GetGeneralPath(InputControl control)
         {
             var path = control.path;
-            var regex = new Regex(@"^\/?[^\/]*\/");
             if (control.device is Mouse)
             {
-                path = regex.Replace(path, "<Mouse>/");
+                path = PathPattern.Replace(path, "<Mouse>/");
             }
             else if (control.device is Gamepad)
             {
-                path = regex.Replace(path, "<Gamepad>/");
+                path = PathPattern.Replace(path, "<Gamepad>/");
             }
             else if (control.device is Keyboard)
             {
-                path = regex.Replace(path, "<Keyboard>/");
+                path = PathPattern.Replace(path, "<Keyboard>/");
             }
 
             return path;


### PR DESCRIPTION
文本量大的时候regex的耗时有点惊人, 我构造了一个只加载20个测试用例
```csharp
                    try
                    {
                        UnityEngine.Profiling.Profiler.BeginSample("ParseScript");
                        ParseScript(script.text);
                        UnityEngine.Profiling.Profiler.EndSample();
                    }
```
![image](https://user-images.githubusercontent.com/1546130/178318012-1e212c3e-5bc3-460a-90d8-c1a4932fe6f5.png)

简单的使用了两个技巧可以砍到一个量级
- 预编译regex
- 使用更强但是更快的IndexOf约束来跳过肯定不必要的Regex

![image](https://user-images.githubusercontent.com/1546130/178318164-b40b7982-cf4f-428e-ba99-14b1fb821224.png)

后面我觉得还需要讨论下，因为目前的写法`.*`会导致backtrack，然后性能暴死……这块也许可以尝试直接人肉分析/考虑利用lua的vm来做？
ps. 其实`GenerateActions`这类操作，我觉得就应该拆到离线去处理...
