### PR TITLE
优化ScriptParsing

### DIFF
--- a/Assets/Nova/Sources/Core/ScriptParsing/Parser/ParseException.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/Parser/ParseException.cs
@@ -25,12 +25,16 @@ namespace Nova.Script
 
         public static void ExpectToken(Token token, TokenType type, string display)
         {
-            ExpectToken(token, new[] {type}, display);
+            if (token.type != type)
+            {
+                throw new ParseException(ErrorMessage(token, $"Expect {display}"));
+            }
         }
 
-        public static void ExpectToken(Token token, TokenType[] types, string display)
+        // TODO: params?
+        public static void ExpectToken(Token token, TokenType typeA, TokenType typeB, string display)
         {
-            if (types.All(t => token.type != t))
+            if (token.type != typeA && token.type != typeB)
             {
                 throw new ParseException(ErrorMessage(token, $"Expect {display}"));
             }

--- a/Assets/Nova/Sources/Core/ScriptParsing/Parser/Parser.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/Parser/Parser.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -203,7 +203,7 @@ namespace Nova.Script
                 }
 
                 tokenizer.SkipWhiteSpace();
-                token = tokenizer.Peek();
+                token = tokenizer.Peek().Duplicate();
                 if (token.type == TokenType.Comma || token.type == TokenType.AttrEnd)
                 {
                     tokenizer.ParseNext();

--- a/Assets/Nova/Sources/Core/ScriptParsing/Parser/Parser.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/Parser/Parser.cs
@@ -31,34 +31,40 @@ namespace Nova.Script
         private static ParsedBlock ParseCodeBlock(Tokenizer tokenizer, BlockType type, AttributeDict attributes)
         {
             ParseException.ExpectToken(tokenizer.Peek(), TokenType.BlockStart, "<|");
-            var startToken = tokenizer.Take();
-            var sb = new StringBuilder();
+            var startToken = tokenizer.Peek().Duplicate();
+            tokenizer.ParseNext();
             var matchFound = false;
+            int startIndex = tokenizer.Peek().index;
+            int endIndex = startIndex;
             while (tokenizer.Peek().type != TokenType.EndOfFile)
             {
                 var token = tokenizer.Peek();
-                if (token.type == TokenType.CommentStart)
+                var tokenType = token.type;
+                var tokenIndex = token.index;
+                var tokenLength = token.length;
+                if (tokenType == TokenType.CommentStart)
                 {
-                    sb.Append(tokenizer.TakeComment());
+                    tokenizer.AdvanceComment();
                     continue;
                 }
 
-                if (token.type == TokenType.Quote)
+                if (tokenType == TokenType.Quote)
                 {
-                    sb.Append(tokenizer.TakeQuoted());
+                    tokenizer.AdvanceQuoted();
                     continue;
                 }
 
-                tokenizer.Take();
+                tokenizer.ParseNext();
 
-                if (token.type == TokenType.BlockEnd)
+                if (tokenType == TokenType.BlockEnd)
                 {
                     matchFound = true;
                     break;
                 }
 
-                sb.Append(token.text);
+                endIndex = tokenIndex + tokenLength;
             }
+            string content = tokenizer.SubString(startIndex, endIndex - startIndex);
 
             if (!matchFound)
             {
@@ -67,24 +73,22 @@ namespace Nova.Script
 
             tokenizer.SkipWhiteSpace();
 
-            ParseException.ExpectToken(tokenizer.Peek(), new[]
-            {
-                TokenType.NewLine, TokenType.EndOfFile
-            }, "new line or end of file after |>");
-            tokenizer.Take();
+            ParseException.ExpectToken(tokenizer.Peek(), TokenType.NewLine,TokenType.EndOfFile, "new line or end of file after |>");
+            tokenizer.ParseNext();
 
             return new ParsedBlock
             {
                 type = type,
                 attributes = attributes,
-                content = sb.ToString()
+                content = content
             };
         }
 
         private static ParsedBlock ParseEagerExecutionBlock(Tokenizer tokenizer)
         {
-            var at = tokenizer.Take();
+            var at = tokenizer.Peek();
             ParseException.ExpectToken(at, TokenType.At, "@");
+            tokenizer.ParseNext();
             var token = tokenizer.Peek();
             if (token.type == TokenType.AttrStart)
             {
@@ -96,22 +100,28 @@ namespace Nova.Script
                 return ParseCodeBlock(tokenizer, BlockType.EagerExecution, new AttributeDict());
             }
 
-            throw new ParseException(token, $"Except [ or <| after @, found {token.text}");
+            throw new ParseException(token, $"Except [ or <| after @, found {token.type}");
         }
 
         private static string ExpectIdentifierOrString(Tokenizer tokenizer)
         {
             if (tokenizer.Peek().type == TokenType.Character)
             {
-                return tokenizer.TakeIdentifier();
+                int startIndex = tokenizer.Peek().index;
+                tokenizer.AdvanceIdentifier();
+                int endIndex = tokenizer.Peek().index;
+                return tokenizer.SubString(startIndex, endIndex - startIndex);
             }
 
             if (tokenizer.Peek().type == TokenType.Quote)
             {
-                return tokenizer.TakeQuoted(false);
+                int startIndex = tokenizer.Peek().index;
+                tokenizer.AdvanceQuoted(false);
+                int endIndex = tokenizer.Peek().index;
+                return tokenizer.SubString(startIndex, endIndex - startIndex);
             }
 
-            throw new ParseException(tokenizer.Peek(), $"Expect identifier or string, found {tokenizer.Peek().text}");
+            throw new ParseException(tokenizer.Peek(), $"Expect identifier or string, found {tokenizer.Peek().type}");
         }
 
         private static char EscapeChar(char c)
@@ -167,7 +177,7 @@ namespace Nova.Script
         private static ParsedBlock ParseCodeBlockWithAttributes(Tokenizer tokenizer, BlockType type)
         {
             ParseException.ExpectToken(tokenizer.Peek(), TokenType.AttrStart, "[");
-            tokenizer.Take();
+            tokenizer.ParseNext();
             var attrs = new AttributeDict();
 
             while (tokenizer.Peek().type != TokenType.EndOfFile)
@@ -176,7 +186,7 @@ namespace Nova.Script
                 var token = tokenizer.Peek();
                 if (token.type == TokenType.AttrEnd)
                 {
-                    tokenizer.Take();
+                    tokenizer.ParseNext();
                     break;
                 }
 
@@ -187,7 +197,7 @@ namespace Nova.Script
                 token = tokenizer.Peek();
                 if (token.type == TokenType.Equal)
                 {
-                    tokenizer.Take();
+                    tokenizer.ParseNext();
                     tokenizer.SkipWhiteSpace();
                     value = ExpectIdentifierOrString(tokenizer);
                 }
@@ -196,7 +206,7 @@ namespace Nova.Script
                 token = tokenizer.Peek();
                 if (token.type == TokenType.Comma || token.type == TokenType.AttrEnd)
                 {
-                    tokenizer.Take();
+                    tokenizer.ParseNext();
                 }
                 else
                 {
@@ -214,42 +224,45 @@ namespace Nova.Script
             return ParseCodeBlock(tokenizer, type, attrs);
         }
 
-        private static ParsedBlock ParseTextBlock(Tokenizer tokenizer, StringBuilder sb)
+        private static ParsedBlock ParseTextBlock(Tokenizer tokenizer, int startIndex)
         {
             while (tokenizer.Peek().type != TokenType.EndOfFile && tokenizer.Peek().type != TokenType.NewLine)
             {
-                sb.Append(tokenizer.Take().text);
+                tokenizer.ParseNext();
             }
+            int endIndex = tokenizer.Peek().index;
+            string content = tokenizer.SubString(startIndex, endIndex - startIndex);
 
             // eat up the last newline
-            tokenizer.Take();
+            tokenizer.ParseNext();
 
             return new ParsedBlock
             {
                 type = BlockType.Text,
-                content = sb.ToString(),
+                content = content,
                 attributes = new AttributeDict()
             };
         }
 
         private static ParsedBlock ParseBlock(Tokenizer tokenizer)
         {
-            var sb = new StringBuilder();
             var token = tokenizer.Peek();
+            int startIndex = token.index;
             while (token.type == TokenType.WhiteSpace)
             {
-                sb.Append(token.text);
-                tokenizer.Take();
+                tokenizer.ParseNext();
                 token = tokenizer.Peek();
             }
+            int endIndex = token.index;
 
             if (token.type == TokenType.NewLine || token.type == TokenType.EndOfFile)
             {
-                tokenizer.Take();
+                string content = tokenizer.SubString(startIndex, endIndex - startIndex);
+                tokenizer.ParseNext();
                 return new ParsedBlock()
                 {
                     type = BlockType.Separator,
-                    content = sb.ToString(),
+                    content = content,
                     attributes = new AttributeDict()
                 };
             }
@@ -269,7 +282,7 @@ namespace Nova.Script
                 return ParseCodeBlock(tokenizer, BlockType.LazyExecution, new AttributeDict());
             }
 
-            return ParseTextBlock(tokenizer, sb);
+            return ParseTextBlock(tokenizer, startIndex);
         }
 
         private static IReadOnlyList<ParsedBlock> MergeConsecutiveSeparators(IReadOnlyList<ParsedBlock> oldBlocks)

--- a/Assets/Nova/Sources/Core/ScriptParsing/Parser/Token.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/Parser/Token.cs
@@ -21,9 +21,22 @@
 
     public class Token
     {
-        public string text;
+        public int index;
+        public int length;
         public int line;
         public int column;
         public TokenType type;
+
+        public Token Duplicate()
+        {
+            return new Token()
+            {
+                index = index,
+                length = length,
+                line = line,
+                column = column,
+                type = type
+            };
+        }
     }
 }

--- a/Assets/Nova/Tests.meta
+++ b/Assets/Nova/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7da5e61a885546d183fa1eda5a1a291
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Nova/Tests/Core.meta
+++ b/Assets/Nova/Tests/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55f721a30082bac4582a6232f1d99913
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Nova/Tests/Core/ScriptParsing.meta
+++ b/Assets/Nova/Tests/Core/ScriptParsing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cc3de5c74416cb4ab839e5c11d4e9c5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Nova/Tests/Core/ScriptParsing/TestParser.cs
+++ b/Assets/Nova/Tests/Core/ScriptParsing/TestParser.cs
@@ -1,0 +1,248 @@
+﻿using Nova.Script;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests
+{
+    public class TestParser
+    {
+        [Test]
+        public void TestParseTextBlock()
+        {
+            var parsed = Parser.Parse(@"
+Text1
+Text2
+
+Text3
+
+");
+
+            Assert.NotNull(parsed);
+            var blocks = parsed.blocks;
+            Assert.AreEqual(4, blocks.Count);
+            foreach (var block in blocks)
+            {
+                Assert.IsNotNull(block.attributes);
+            }
+
+            Assert.AreEqual(BlockType.Text, blocks[0].type);
+            Assert.AreEqual("Text1", blocks[0].content);
+            Assert.AreEqual(BlockType.Text, blocks[1].type);
+            Assert.AreEqual("Text2", blocks[1].content);
+            Assert.AreEqual(BlockType.Separator, blocks[2].type);
+            Assert.AreEqual(BlockType.Text, blocks[3].type);
+            Assert.AreEqual("Text3", blocks[3].content);
+        }
+
+        [Test]
+        public void TestParseExecutionBlock()
+        {
+            var parsed = Parser.Parse(@"
+<| code1() |>
+<| code2() |>
+
+@<| code3() |>
+
+
+");
+
+            Assert.NotNull(parsed);
+            var blocks = parsed.blocks;
+            Assert.AreEqual(4, blocks.Count);
+            foreach (var block in blocks)
+            {
+                Assert.IsNotNull(block.attributes);
+            }
+
+            Assert.AreEqual(BlockType.LazyExecution, blocks[0].type);
+            Assert.AreEqual(" code1() ", blocks[0].content);
+            Assert.AreEqual(BlockType.LazyExecution, blocks[1].type);
+            Assert.AreEqual(" code2() ", blocks[1].content);
+            Assert.AreEqual(BlockType.Separator, blocks[2].type);
+            Assert.AreEqual(BlockType.EagerExecution, blocks[3].type);
+            Assert.AreEqual(" code3() ", blocks[3].content);
+        }
+
+        [Test]
+        public void TestParseComment()
+        {
+            var parsed = Parser.Parse(@"
+<|-- Comment |>
+code1() |>
+<| code2() |>
+
+@<| --[[ Comment |> ]] code3() |>
+");
+
+            Assert.NotNull(parsed);
+            var blocks = parsed.blocks;
+            Assert.AreEqual(4, blocks.Count);
+            foreach (var block in blocks)
+            {
+                Assert.IsNotNull(block.attributes);
+            }
+
+            Assert.AreEqual(BlockType.LazyExecution, blocks[0].type);
+            Assert.AreEqual("-- Comment |>\ncode1() ", blocks[0].content);
+            Assert.AreEqual(BlockType.LazyExecution, blocks[1].type);
+            Assert.AreEqual(" code2() ", blocks[1].content);
+            Assert.AreEqual(BlockType.Separator, blocks[2].type);
+            Assert.AreEqual(BlockType.EagerExecution, blocks[3].type);
+            Assert.AreEqual(" --[[ Comment |> ]] code3() ", blocks[3].content);
+        }
+
+        [Test]
+        public void TestParserSimple()
+        {
+            var parsed = Parser.Parse(@"
+@<| hello_world |>
+
+<|
+--[[ <| |> ]] |>
+Text
+
+");
+            Assert.NotNull(parsed);
+            var blocks = parsed.blocks;
+            Assert.AreEqual(blocks.Count, 4);
+            foreach (var block in blocks)
+            {
+                Assert.IsNotNull(block.attributes);
+            }
+
+            Assert.AreEqual(blocks[0].type, BlockType.EagerExecution);
+            Assert.AreEqual(blocks[0].content, " hello_world ");
+            Assert.AreEqual(blocks[1].type, BlockType.Separator);
+            Assert.AreEqual(blocks[2].type, BlockType.LazyExecution);
+            Assert.AreEqual(blocks[2].content, "\n--[[ <| |> ]] ");
+            Assert.AreEqual(blocks[3].type, BlockType.Text);
+            Assert.AreEqual(blocks[3].content, "Text");
+        }
+
+        [Test]
+        public void TestBlockWithEmptyLine()
+        {
+            var parsed = Parser.Parse(@"
+<| code1() |>
+<| code2()
+
+code2_2() |>
+
+@<| code3() |>
+
+
+");
+
+            Assert.NotNull(parsed);
+            var blocks = parsed.blocks;
+            Assert.AreEqual(4, blocks.Count);
+            foreach (var block in blocks)
+            {
+                Assert.IsNotNull(block.attributes);
+            }
+
+            Assert.AreEqual(BlockType.LazyExecution, blocks[0].type);
+            Assert.AreEqual(" code1() ", blocks[0].content);
+            Assert.AreEqual(BlockType.LazyExecution, blocks[1].type);
+            Assert.AreEqual(" code2()\n\ncode2_2() ", blocks[1].content);
+            Assert.AreEqual(BlockType.Separator, blocks[2].type);
+            Assert.AreEqual(BlockType.EagerExecution, blocks[3].type);
+            Assert.AreEqual(" code3() ", blocks[3].content);
+        }
+
+        [Test]
+        public void TestUnpaired()
+        {
+            try
+            {
+                var parsed =  Parser.Parse("<| code_unpaired");
+            }
+            catch (ParseException)
+            {
+                Assert.IsTrue(true);
+                return;
+            }
+
+            Assert.IsTrue(false, "Exception not thrown");
+        }
+
+        [Test]
+        public void TestString()
+        {
+            var parsed =  Parser.Parse(@"
+<| print 'hello\' |>' |>
+<| code2()
+
+[[
+multiline[[nested |>]]
+]]
+
+code2_2() |>
+
+@<| code3() |>
+
+
+");
+
+            Assert.NotNull(parsed);
+            var blocks = parsed.blocks;
+            Assert.AreEqual(4, blocks.Count);
+            foreach (var block in blocks)
+            {
+                Assert.IsNotNull(block.attributes);
+            }
+
+            Assert.AreEqual(BlockType.LazyExecution, blocks[0].type);
+            Assert.IsTrue(blocks[0].attributes.Count == 0);
+            Assert.AreEqual(" print 'hello\\' |>' ", blocks[0].content);
+            Assert.AreEqual(BlockType.LazyExecution, blocks[1].type);
+            Assert.IsTrue(blocks[1].attributes.Count == 0);
+            Assert.AreEqual(" code2()\n\n[[\nmultiline[[nested |>]]\n]]\n\ncode2_2() ", blocks[1].content);
+            Assert.AreEqual(BlockType.Separator, blocks[2].type);
+            Assert.AreEqual(BlockType.EagerExecution, blocks[3].type);
+            Assert.IsTrue(blocks[3].attributes.Count == 0);
+            Assert.AreEqual(" code3() ", blocks[3].content);
+        }
+
+        [Test]
+        public void TestAttribute()
+        {
+            var parsed =  Parser.Parse(@"
+[label = entry, '$name' = 'hello\' world']<|
+print 'hello\' |>' |>
+<| code2()
+
+[[
+multiline[[nested |>]]
+]]
+
+code2_2() |>
+
+@[flag]<| code3() |>
+
+
+");
+
+            Assert.NotNull(parsed);
+            var blocks = parsed.blocks;
+            Assert.AreEqual(4, blocks.Count);
+            foreach (var block in blocks)
+            {
+                Assert.IsNotNull(block.attributes);
+            }
+
+            Assert.AreEqual(BlockType.LazyExecution, blocks[0].type);
+            Assert.AreEqual("\nprint 'hello\\' |>' ", blocks[0].content);
+            Assert.AreEqual("entry", blocks[0].attributes["label"]);
+            Assert.AreEqual("hello\' world", blocks[0].attributes["$name"]);
+            Assert.AreEqual(BlockType.LazyExecution, blocks[1].type);
+            Assert.IsTrue(blocks[1].attributes.Count == 0);
+            Assert.AreEqual(" code2()\n\n[[\nmultiline[[nested |>]]\n]]\n\ncode2_2() ", blocks[1].content);
+            Assert.AreEqual(BlockType.Separator, blocks[2].type);
+            Assert.AreEqual(BlockType.EagerExecution, blocks[3].type);
+            Assert.IsTrue(blocks[3].attributes.ContainsKey("flag"));
+            Assert.IsNull(blocks[3].attributes["flag"]);
+            Assert.AreEqual(" code3() ", blocks[3].content);
+        }
+    }
+}

--- a/Assets/Nova/Tests/Core/ScriptParsing/TestParser.cs.meta
+++ b/Assets/Nova/Tests/Core/ScriptParsing/TestParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46f399b621a03b544bd3fe0270bce1f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Nova/Tests/Tests.asmdef
+++ b/Assets/Nova/Tests/Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Nova.Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Nova"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Nova/Tests/Tests.asmdef.meta
+++ b/Assets/Nova/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f8f00ce3857f2e342a7ad369d8c25a7c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,6 +3,7 @@
     "com.unity.inputsystem": "1.4.1",
     "com.unity.nuget.newtonsoft-json": "3.0.2",
     "com.unity.render-pipelines.universal": "10.9.0",
+    "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.1",
     "com.unity.modules.assetbundle": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.inputsystem": {
       "version": "1.4.1",
       "depth": 0,
@@ -59,6 +66,17 @@
       "dependencies": {
         "com.unity.render-pipelines.core": "10.9.0",
         "com.unity.searcher": "4.3.2"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.1.31",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -127,13 +145,13 @@
     },
     "com.unity.modules.imgui": {
       "version": "1.0.0",
-      "depth": 2,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },
     "com.unity.modules.jsonserialize": {
       "version": "1.0.0",
-      "depth": 2,
+      "depth": 1,
       "source": "builtin",
       "dependencies": {}
     },


### PR DESCRIPTION
rt 主要是工程角度优化，减少不必要的substring操作(大量TakeXXX改成AdvanceXXX)
我做了两个测试维度
- 正常启动加载875个script，优化前`Parser.Parse(script.text).blocks`需要20.51s,优化后3.82s
- 单独DeepProfile了同一个文件处理20次对比
![image](https://user-images.githubusercontent.com/1546130/178763922-0624e710-1d75-4c41-8f68-36c7a0391d18.png)
![image](https://user-images.githubusercontent.com/1546130/178763987-2450b23e-0bb9-40fb-83d2-4271de6a3ea7.png)

为了保证内容正确还用Nova的范例工程测了下前后一致
```csharp
var blocks = Parser.Parse(script.text).blocks;

List<string> temp = new List<string>();
temp.Add(script.name);
foreach (var block in blocks)
{
    temp.Add(block.type.ToString());
    temp.Add(block.content);
}
System.IO.File.AppendAllLines("parsedopt.txt", temp);
```