### PR TITLE
impl LogWindow with LoopScrollRect

### DIFF
--- a/Assets/Nova/Prefabs/Log/LogEntry.prefab
+++ b/Assets/Nova/Prefabs/Log/LogEntry.prefab
@@ -119,6 +119,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
 --- !u!114 &114976569138266534
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -133,6 +134,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -222,6 +224,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -297,6 +300,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -325,6 +329,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -471,6 +476,7 @@ MonoBehaviour:
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!114 &114923897484395330
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -549,6 +555,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -556,8 +563,7 @@ MonoBehaviour:
   m_text: "\u6D4B\u8BD5\n\u5F88\u591A\u884C\n\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\u5F88\u957F\n\u7684\u6587\u5B57"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 224d1ec448c92dc428ff88f37d4fed71, type: 2}
-  m_sharedMaterial: {fileID: 21833747971602348, guid: 224d1ec448c92dc428ff88f37d4fed71,
-    type: 2}
+  m_sharedMaterial: {fileID: 21833747971602348, guid: 224d1ec448c92dc428ff88f37d4fed71, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/Nova/Prefabs/Log/LogView.prefab
+++ b/Assets/Nova/Prefabs/Log/LogView.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 779502757}
-  - component: {fileID: 779502758}
+  - component: {fileID: 1442086682}
   m_Layer: 5
   m_Name: ScrollView
   m_TagString: Untagged
@@ -38,7 +38,7 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -10}
   m_SizeDelta: {x: 0, y: -160}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &779502758
+--- !u!114 &1442086682
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -47,9 +47,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 779502756}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Script: {fileID: 11500000, guid: ce71017a2903f7c4c9a699e438d0b897, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  totalCount: 0
+  reverseDirection: 0
+  rubberScale: 1
   m_Content: {fileID: 224505783455509500}
   m_Horizontal: 0
   m_Vertical: 1
@@ -61,7 +64,7 @@ MonoBehaviour:
   m_Viewport: {fileID: 224556054209721956}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 114732660024768836}
-  m_HorizontalScrollbarVisibility: 2
+  m_HorizontalScrollbarVisibility: 0
   m_VerticalScrollbarVisibility: 1
   m_HorizontalScrollbarSpacing: -3
   m_VerticalScrollbarSpacing: -3
@@ -132,6 +135,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -160,6 +164,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -379,6 +384,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -407,6 +413,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 0
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -543,8 +550,8 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -20, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
-  m_Pivot: {x: 1, y: 1}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 1, y: 0}
 --- !u!222 &222889604335973886
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -568,6 +575,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -596,6 +604,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -623,7 +632,7 @@ MonoBehaviour:
   m_Interactable: 1
   m_TargetGraphic: {fileID: 114403553577028260}
   m_HandleRect: {fileID: 224025336173628976}
-  m_Direction: 2
+  m_Direction: 3
   m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
@@ -692,6 +701,7 @@ MonoBehaviour:
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!114 &114008115867345432
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -781,6 +791,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -828,9 +839,9 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 20}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 5, y: 0}
+  m_SizeDelta: {x: 10, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &222253014555062622
 CanvasRenderer:
@@ -855,6 +866,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 0.545, g: 0.545, b: 0.545, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:

--- a/Assets/Nova/Prefabs/Log/LogView.prefab
+++ b/Assets/Nova/Prefabs/Log/LogView.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   myPanel: {fileID: 1449025792155100}
-  maxLogEntryNum: 100
+  maxLogEntryNum: 1000
   logEntryPrefab: {fileID: 114923897484395330, guid: dfddb504ea35c40f7911f1fc6e70a265,
     type: 3}
   closeButton: {fileID: 2573426190844929647}

--- a/Assets/Nova/Sources/Nova.asmdef
+++ b/Assets/Nova/Sources/Nova.asmdef
@@ -4,7 +4,8 @@
         "Unity.TextMeshPro",
         "Unity.RenderPipelines.Core.Runtime",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.InputSystem"
+        "Unity.InputSystem",
+        "LoopScrollRect.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Nova/Sources/Scripts/UI/LogEntryController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/LogEntryController.cs
@@ -1,11 +1,11 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.Events;
 using UnityEngine.UI;
 
 namespace Nova
 {
-    public class LogEntryController : MonoBehaviour, IPointerExitHandler
+    public class LogEntryController : MonoBehaviour, IPointerExitHandler, ILayoutElement
     {
         [HideInInspector] public int logEntryIndex;
 
@@ -15,6 +15,20 @@ namespace Nova
         private DialogueDisplayData displayData;
         private bool inited;
 
+        # region Layout
+        private float height;
+        public float minWidth { get { return -1; } }
+        public float preferredWidth { get { return -1; } }
+        public float flexibleWidth { get { return -1; } }
+        public float minHeight { get { return -1; } }
+        public float preferredHeight { get { return height; } }
+        public float flexibleHeight { get { return -1; } }
+        public int layoutPriority { get { return 1; } } // override VerticalLayoutGroup
+
+        public void CalculateLayoutInputHorizontal() { }
+        public void CalculateLayoutInputVertical() { }
+        # endregion
+    
         private void InitReferences()
         {
             if (inited) return;
@@ -66,7 +80,7 @@ namespace Nova
         /// <param name="onPlayVoiceButtonClicked">The action to perform when the play voice button clicked</param>
         /// <param name="logEntryIndex"></param>
         public void Init(DialogueDisplayData displayData, UnityAction<int> onGoBackButtonClicked,
-            UnityAction onPlayVoiceButtonClicked, UnityAction<int> onPointerExit, int logEntryIndex)
+            UnityAction onPlayVoiceButtonClicked, UnityAction<int> onPointerExit, int logEntryIndex, float height)
         {
             InitReferences();
             this.logEntryIndex = logEntryIndex;
@@ -76,13 +90,13 @@ namespace Nova
             this.onPointerExit = onPointerExit;
             this.displayData = displayData;
             UpdateText();
+            this.height = height;
         }
 
         private void UpdateText()
         {
             if (!inited) return;
             textProxy.text = displayData.FormatNameDialogue();
-            gameObject.SetActive(!string.IsNullOrEmpty(textProxy.text));
         }
 
         private void OnEnable()

--- a/Assets/Nova/Sources/Scripts/UI/LogEntryController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/LogEntryController.cs
@@ -15,20 +15,22 @@ namespace Nova
         private DialogueDisplayData displayData;
         private bool inited;
 
-        # region Layout
+        #region Layout
+
         private float height;
-        public float minWidth { get { return -1; } }
-        public float preferredWidth { get { return -1; } }
-        public float flexibleWidth { get { return -1; } }
-        public float minHeight { get { return -1; } }
-        public float preferredHeight { get { return height; } }
-        public float flexibleHeight { get { return -1; } }
-        public int layoutPriority { get { return 1; } } // override VerticalLayoutGroup
+        public float minWidth => -1;
+        public float preferredWidth => -1;
+        public float flexibleWidth => -1;
+        public float minHeight => -1;
+        public float preferredHeight => height;
+        public float flexibleHeight => -1;
+        public int layoutPriority => 1; // override VerticalLayoutGroup
 
         public void CalculateLayoutInputHorizontal() { }
         public void CalculateLayoutInputVertical() { }
-        # endregion
-    
+
+        #endregion
+
         private void InitReferences()
         {
             if (inited) return;
@@ -72,13 +74,6 @@ namespace Nova
             onPointerExit?.Invoke(logEntryIndex);
         }
 
-        /// <summary>
-        /// Initialize the log entry prefab
-        /// </summary>
-        /// <param name="displayData"></param>
-        /// <param name="onGoBackButtonClicked">The action to perform when the go back button clicked</param>
-        /// <param name="onPlayVoiceButtonClicked">The action to perform when the play voice button clicked</param>
-        /// <param name="logEntryIndex"></param>
         public void Init(DialogueDisplayData displayData, UnityAction<int> onGoBackButtonClicked,
             UnityAction onPlayVoiceButtonClicked, UnityAction<int> onPointerExit, int logEntryIndex, float height)
         {

--- a/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
@@ -34,7 +34,7 @@ namespace Nova
             }
         }
 
-        public int maxLogEntryNum = 100;
+        public int maxLogEntryNum = 1000;
         public LogEntryController logEntryPrefab;
         public Button closeButton;
         public bool hideOnGoBackButtonClicked;

--- a/Assets/Nova/Sources/Scripts/UI/Views/ViewControllerBase.cs
+++ b/Assets/Nova/Sources/Scripts/UI/Views/ViewControllerBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -47,7 +47,7 @@ namespace Nova
             myPanel.SetActive(false);
         }
 
-        protected void ForceRebuildLayoutAndResetTransitionTarget()
+        protected virtual void ForceRebuildLayoutAndResetTransitionTarget()
         {
             // Rebuild all layouts the hard way
             foreach (var layout in GetComponentsInChildren<LayoutGroup>())

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -5232,6 +5232,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: LogView
       objectReference: {fileID: 0}
+    - target: {fileID: 114670746149515138, guid: 60803c007c3ce4e5a876197907c5c3aa, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 224649617486178882, guid: 60803c007c3ce4e5a876197907c5c3aa, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -3137,7 +3137,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5.000122, y: 0}
+  m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1154972744
@@ -5234,7 +5234,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 114670746149515138, guid: 60803c007c3ce4e5a876197907c5c3aa, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 224649617486178882, guid: 60803c007c3ce4e5a876197907c5c3aa, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -3137,7 +3137,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
+  m_AnchoredPosition: {x: -5.000122, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1154972744
@@ -5231,10 +5231,6 @@ PrefabInstance:
     - target: {fileID: 1292923931800236, guid: 60803c007c3ce4e5a876197907c5c3aa, type: 3}
       propertyPath: m_Name
       value: LogView
-      objectReference: {fileID: 0}
-    - target: {fileID: 114670746149515138, guid: 60803c007c3ce4e5a876197907c5c3aa, type: 3}
-      propertyPath: m_Enabled
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 224649617486178882, guid: 60803c007c3ce4e5a876197907c5c3aa, type: 3}
       propertyPath: m_Pivot.x

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,10 +1,20 @@
 {
+  "scopedRegistries": [
+    {
+      "name": "package.openupm.cn",
+      "url": "https://package.openupm.cn",
+      "scopes": [
+        "me.qiankanglai.loopscrollrect"
+      ]
+    }
+  ],
   "dependencies": {
     "com.unity.inputsystem": "1.4.1",
     "com.unity.nuget.newtonsoft-json": "3.0.2",
     "com.unity.render-pipelines.universal": "10.9.0",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.1",
+    "me.qiankanglai.loopscrollrect": "1.1.2",
     "com.unity.modules.assetbundle": "1.0.0",
     "com.unity.modules.imageconversion": "1.0.0",
     "com.unity.modules.physics": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -92,6 +92,15 @@
         "com.unity.modules.imgui": "1.0.0"
       }
     },
+    "me.qiankanglai.loopscrollrect": {
+      "version": "1.1.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://package.openupm.cn"
+    },
     "com.unity.modules.animation": {
       "version": "1.0.0",
       "depth": 1,

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -12,11 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_EnablePreReleasePackages: 0
+  m_EnablePreviewPackages: 0
   m_EnablePackageDependencies: 0
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
-  m_SeeAllPackageVersions: 1
   oneTimeWarningShown: 0
   m_Registries:
   - m_Id: main
@@ -25,20 +24,28 @@ MonoBehaviour:
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
+  - m_Id: scoped:package.openupm.cn
+    m_Name: package.openupm.cn
+    m_Url: https://package.openupm.cn
+    m_Scopes:
+    - me.qiankanglai.loopscrollrect
+    m_IsDefault: 0
+    m_Capabilities: 0
   m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 
     m_Original:
-      m_Id: 
-      m_Name: 
-      m_Url: 
-      m_Scopes: []
+      m_Id: scoped:package.openupm.cn
+      m_Name: package.openupm.cn
+      m_Url: https://package.openupm.cn
+      m_Scopes:
+      - me.qiankanglai.loopscrollrect
       m_IsDefault: 0
       m_Capabilities: 0
     m_Modified: 0
-    m_Name: 
-    m_Url: 
+    m_Name: package.openupm.cn
+    m_Url: https://package.openupm.cn
     m_Scopes:
-    - 
+    - me.qiankanglai.loopscrollrect
     m_SelectedScopeIndex: 0


### PR DESCRIPTION
之前遇到的文本不规则问题处理了下
目前写的比较丑或者说需要讨论的地方
- 为了精确获得文本大小，实例化了一个`logEntryForTest`用于`GetPreferredValues`
- 目前layout里的大小我是直接代码里写死`rect.width -= 180 * 2;` 因为俩LayoutGroup里的Padding分别是80和100，这个可能要改成代码里去读取而不是硬编码
- 还有一个潜规则是空文本的LogEntry是被disable的，但这个会打乱布局计算，我改成了直接在`AddEntry`的地方就return掉，不知道对别的模块譬如存档有没有影响(因为我看`logEntryIndex`是似乎是纯排序用的?)