### PR TITLE
Minor bugfix: Applied boundary check.

### DIFF
--- a/Assets/Nova/Sources/Scripts/UI/TextProxy.cs
+++ b/Assets/Nova/Sources/Scripts/UI/TextProxy.cs
@@ -232,7 +232,8 @@ namespace Nova
         private void ApplyAlphaToCharAtIndex(int index, byte alpha)
         {
             var characterInfo = textBox.textInfo.characterInfo;
-            // TODO: skip animation for invisible characters?
+            // TODO: skip animation for invisible characters? <- Boundary Check Applied
+            if (characterInfo.Length <= index) return;
             if (!characterInfo[index].isVisible) return;
 
             // Characters at different indices may have different materials


### PR DESCRIPTION
Add boundary check for TextProxy.ApplyAlphaToCharAtIndex, sometimes it may throw error for out-of-index access.