### PR TITLE
try defer load node when possible

### DIFF
--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -602,6 +602,7 @@ namespace Nova
         private void GameStart(FlowChartNode startNode)
         {
             ResetGameState();
+            scriptLoader.DeferredAddDialogueChunks(startNode);
             MoveToNextNode(startNode, null);
         }
 

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -71,12 +71,8 @@ namespace Nova
                 this.active = active;
             }
 
-            public Selection(string text, BranchImageInformation imageInfo, bool active)
-                : this(new Dictionary<SystemLanguage, string>
-                {
-                    [I18n.DefaultLocale] = text
-                }, imageInfo, active)
-            { }
+            public Selection(string text, BranchImageInformation imageInfo, bool active) : this(
+                new Dictionary<SystemLanguage, string> {[I18n.DefaultLocale] = text}, imageInfo, active) { }
         }
 
         public readonly IReadOnlyList<Selection> selections;
@@ -516,6 +512,7 @@ namespace Nova
 
         private void MoveToNextNode(FlowChartNode nextNode, Action onFinish)
         {
+            scriptLoader.AddDeferredDialogueChunks(nextNode);
             nodeHistory.Add(nextNode.name);
             currentNode = nextNode;
             currentIndex = 0;
@@ -602,7 +599,6 @@ namespace Nova
         private void GameStart(FlowChartNode startNode)
         {
             ResetGameState();
-            scriptLoader.DeferredAddDialogueChunks(startNode);
             MoveToNextNode(startNode, null);
         }
 

--- a/Assets/Nova/Sources/Core/ScriptParsing/FlowChartNode.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/FlowChartNode.cs
@@ -95,6 +95,8 @@ namespace Nova
 
         public int dialogueEntryCount => dialogueEntries.Count;
 
+        public IReadOnlyList<ScriptLoader.Chunk> deferredChunks = null;
+
         public void SetDialogueEntries(IReadOnlyList<DialogueEntry> entries)
         {
             CheckFreeze();

--- a/Assets/Nova/Sources/Core/ScriptParsing/FlowChartNode.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/FlowChartNode.cs
@@ -95,7 +95,8 @@ namespace Nova
 
         public int dialogueEntryCount => dialogueEntries.Count;
 
-        public IReadOnlyList<ScriptLoader.Chunk> deferredChunks = null;
+        public readonly Dictionary<SystemLanguage, IReadOnlyList<ScriptLoader.Chunk>> deferredChunks =
+            new Dictionary<SystemLanguage, IReadOnlyList<ScriptLoader.Chunk>>();
 
         public void SetDialogueEntries(IReadOnlyList<DialogueEntry> entries)
         {

--- a/Assets/Nova/Sources/Core/ScriptParsing/ScriptLoader.cs
+++ b/Assets/Nova/Sources/Core/ScriptParsing/ScriptLoader.cs
@@ -261,7 +261,7 @@ namespace Nova
             }
         }
 
-        public void DeferredAddDialogueChunks(FlowChartNode node)
+        public void AddDeferredDialogueChunks(FlowChartNode node)
         {
             if (node.deferredChunks.Count == 0)
             {


### PR DESCRIPTION
其实是issue #14 和issue #15 相关工作，继续优化文本量大的时候的启动速度。差不多从10s砍到3s不到~

我Profile了下发现目前比较重的耗时是出现在`ParseDialogueEntries`里，但是章节相关的其实在`EagarExecution`里已经准备好了。所以索性尝试延后处理，毕竟分担到单独加载某个章节的时候再处理也来得及(其实是暂时懒得继续扣细节了orz)

麻烦看一下这个做法有没有潜在问题，我们目前自测下来正常，不过用的功能不全所以吃不准~