### PR TITLE
将DialogueBackground添加回Scene

### DIFF
--- a/Assets/Nova/Prefabs/Dialogue/DialogueBox.prefab
+++ b/Assets/Nova/Prefabs/Dialogue/DialogueBox.prefab
@@ -31,7 +31,7 @@ RectTransform:
   m_Children:
   - {fileID: 1420761051}
   m_Father: {fileID: 224765096667986850}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -228,7 +228,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   myPanel: {fileID: 1572506572459116}
   dialogueUpdateMode: 0
-  backgroundPrefab: {fileID: 0}
+  background: {fileID: 0}
   luaGlobalName: 
   readColor: {r: 0, g: 0, b: 0, a: 1}
   unreadColor: {r: 0, g: 0, b: 0, a: 1}
@@ -294,6 +294,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 7542057107106432846}
   - {fileID: 952209682}
   - {fileID: 390191758}
   m_Father: {fileID: 224981068127226408}
@@ -439,6 +440,41 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!1 &8393692371078852098
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7542057107106432846}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7542057107106432846
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8393692371078852098}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224765096667986850}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &5655490265359441721
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -460,7 +496,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5655490265707447735, guid: 17a775431dfb1f24fbadee6948ef9923, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5655490265707447735, guid: 17a775431dfb1f24fbadee6948ef9923, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Nova/Prefabs/GameView.prefab
+++ b/Assets/Nova/Prefabs/GameView.prefab
@@ -258,7 +258,6 @@ MonoBehaviour:
   myPanel: {fileID: 2076122711636237511}
   autoModeIcon: {fileID: 2076122711261636900}
   fastForwardModeIcon: {fileID: 2076122711908715774}
-  gameUIController: {fileID: 4192026787445547187}
   currentDialogueBox: {fileID: 7407554439087517767}
 --- !u!114 &2076122711366167401
 MonoBehaviour:
@@ -493,10 +492,10 @@ RectTransform:
   m_Father: {fileID: 475214370034597641}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &3611830721205228200
 MonoBehaviour:
@@ -566,10 +565,10 @@ RectTransform:
   m_Father: {fileID: 2076122711636237510}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &4192026787445547187
 MonoBehaviour:
@@ -621,11 +620,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2124973209742998392, guid: 1af0bb5522ef0274d993606b4e6e866e, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1820.0001
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2124973209742998392, guid: 1af0bb5522ef0274d993606b4e6e866e, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 980
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2124973209742998392, guid: 1af0bb5522ef0274d993606b4e6e866e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -815,14 +814,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: BasicDialogueBox
       objectReference: {fileID: 0}
-    - target: {fileID: 1515438340287766, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 114530638897265038, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: m_Padding.m_Bottom
       value: 120
       objectReference: {fileID: 0}
+    - target: {fileID: 114698272224023466, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
+      propertyPath: background
+      value: 
+      objectReference: {fileID: 936786061024272911}
     - target: {fileID: 114698272224023466, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: luaGlobalName
       value: basic_box
@@ -869,11 +868,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1820.0001
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 980
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: m_LocalPosition.x
@@ -928,6 +927,11 @@ PrefabInstance:
 --- !u!224 &2292496645576607752 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
+  m_PrefabInstance: {fileID: 2076122712534090272}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8387138888425866606 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7542057107106432846, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
   m_PrefabInstance: {fileID: 2076122712534090272}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4016463105500824368
@@ -1032,6 +1036,132 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5647904414854803400, guid: ccd57c91cbb709e4eb0a50ea1f3e902b, type: 3}
   m_PrefabInstance: {fileID: 4016463105500824368}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7154500585066348339
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8387138888425866606}
+    m_Modifications:
+    - target: {fileID: 1640253896577308031, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1640253896577308031, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1640253896577308031, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1640253896577308031, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1640253896577308031, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1640253896577308031, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001980, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_Name
+      value: BasicBackground
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7947100264230001981, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+--- !u!1 &936786061024272911 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7947100264230001980, guid: cd0f204e24e8ba940b699f8fa2b4fb6e, type: 3}
+  m_PrefabInstance: {fileID: 7154500585066348339}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7447712415588705261
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1104,6 +1234,10 @@ PrefabInstance:
       value: DefaultDialogueBox
       objectReference: {fileID: 0}
     - target: {fileID: 114698272224023466, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
+      propertyPath: background
+      value: 
+      objectReference: {fileID: 2471129390195777543}
+    - target: {fileID: 114698272224023466, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: luaGlobalName
       value: default_box
       objectReference: {fileID: 0}
@@ -1149,11 +1283,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 1820.0001
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: m_SizeDelta.y
-      value: 980
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1253,6 +1387,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
+--- !u!224 &7225143714845764037 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
+  m_PrefabInstance: {fileID: 7447712415588705261}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7407554439087517767 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114698272224023466, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
@@ -1264,8 +1403,134 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a62cf927628e24326bffdf99556c4ed1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &7225143714845764037 stripped
+--- !u!224 &1148789547436631203 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 224981068127226408, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7542057107106432846, guid: ba2f88a38a7e341dd95278c30faf99d9, type: 3}
   m_PrefabInstance: {fileID: 7447712415588705261}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &9182170023233012482
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1148789547436631203}
+    m_Modifications:
+    - target: {fileID: 2714604345889696862, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2714604345889696862, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2714604345889696862, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2714604345889696862, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2714604345889696862, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2714604345889696862, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747716, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6712239120865747717, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+      propertyPath: m_Name
+      value: DefaultBackground
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+--- !u!1 &2471129390195777543 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6712239120865747717, guid: 39b0b1de594fd0a428fa08d6f87ca5ad, type: 3}
+  m_PrefabInstance: {fileID: 9182170023233012482}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Nova/Sources/Scripts/UI/Views/DialogueBoxController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/Views/DialogueBoxController.cs
@@ -80,7 +80,7 @@ namespace Nova
 
         public RectTransform rect { get; private set; }
 
-        [SerializeField] private GameObject backgroundPrefab;
+        public GameObject background;
         private Image backgroundImage;
         private CanvasGroup backgroundCanvasGroup;
         private Button hideDialogueButton;
@@ -145,8 +145,6 @@ namespace Nova
 
             rect = transform.Find("DialoguePanel").GetComponent<RectTransform>();
 
-            var background = Instantiate(backgroundPrefab, myPanel.transform);
-            background.transform.SetSiblingIndex(0);
             backgroundImage = background.GetComponent<Image>();
             backgroundCanvasGroup = background.GetComponent<CanvasGroup>();
             hideDialogueButton = background.transform.Find("CloseButton").GetComponent<Button>();

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -241,6 +241,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   marginColor: {r: 0, g: 0, b: 0, a: 0}
   desiredAspectRatio: 1.7777778
+  smoothTime: 0.1
   gameRenderTarget: {fileID: 937997459}
   fullScreenToggle: {fileID: 255584305}
 --- !u!4 &339668545
@@ -4001,6 +4002,30 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6539693649535954780, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6539693649535954780, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6539693649535954780, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6539693649535954780, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6539693649535954780, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6539693649535954780, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7447712415433603452, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
       propertyPath: avatarConfigs.Array.data[0].characterController
       value: 
@@ -4017,6 +4042,30 @@ PrefabInstance:
       propertyPath: avatarConfigs.Array.data[3].characterController
       value: 
       objectReference: {fileID: 1285618328}
+    - target: {fileID: 8469791344066619980, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8469791344066619980, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8469791344066619980, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8469791344066619980, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8469791344066619980, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8469791344066619980, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
 --- !u!114 &2076122710952862908 stripped


### PR DESCRIPTION
之前将DialogueBackground改成了Prefab动态加载是因为Unity不允许改变Prefab里GO的次序，因此只能往末尾添加新的GO。其实只要加一级GO就可以往Prefab里加Background了
这样可以在Editor里看到Background的样子，方便调试。最好也加一个DialogueEntry能看排版样式，不过手动拖进去其实就行