### PR TITLE
统一Lua、`AutoVoice`、`AvatarController`中的角色名称

### DIFF
--- a/Assets/Nova/Lua/pose.lua
+++ b/Assets/Nova/Lua/pose.lua
@@ -1,15 +1,15 @@
 local poses = {
-    ['ergong'] = {
+    ['王二宫'] = {
         ['normal'] = 'body+mouth_smile+eye_normal+eyebrow_normal+hair',
     },
-    ['gaotian'] = {
+    ['陈高天'] = {
         ['normal'] = 'body+mouth_smile+eye_normal+eyebrow_normal+hair',
         ['cry'] = 'body+mouth_smile+eye_cry+eyebrow_normal+hair',
     },
-    ['qianye'] = {
+    ['张浅野'] = {
         ['normal'] = 'body+mouth_close+eye_normal+eyebrow_normal+hair',
     },
-    ['xiben'] = {
+    ['孙西本'] = {
         ['normal'] = 'body+mouth_close+eye_normal+eyebrow_normal+hair',
     },
 

--- a/Assets/Nova/Prefabs/Dialogue/Avatar.prefab
+++ b/Assets/Nova/Prefabs/Dialogue/Avatar.prefab
@@ -300,19 +300,14 @@ MonoBehaviour:
   mergerPrimary: {fileID: 9095240965259948810}
   mergerSub: {fileID: 8279322227598488837}
   imageFolder: Faces
-  luaGlobalName: avatar
   avatarConfigs:
-  - characterName: "\u738B\u4E8C\u5BAB"
-    characterController: {fileID: 0}
+  - characterController: {fileID: 0}
     prefix: Ergong/
-  - characterName: "\u5F20\u6D45\u91CE"
-    characterController: {fileID: 0}
+  - characterController: {fileID: 0}
     prefix: Qianye/
-  - characterName: "\u5B59\u897F\u672C"
-    characterController: {fileID: 0}
+  - characterController: {fileID: 0}
     prefix: Xiben/
-  - characterName: "\u9648\u9AD8\u5929"
-    characterController: {fileID: 0}
+  - characterController: {fileID: 0}
     prefix: Gaotian/
   textPadding: 200
   renderCamera: {fileID: 4498232183032504786}

--- a/Assets/Nova/Sources/Scripts/AutoVoice.cs
+++ b/Assets/Nova/Sources/Scripts/AutoVoice.cs
@@ -8,7 +8,6 @@ namespace Nova
     [Serializable]
     public class AutoVoiceConfig
     {
-        public string characterName;
         public GameCharacterController characterController;
         public string prefix;
     }
@@ -35,7 +34,7 @@ namespace Nova
 
             foreach (var config in autoVoiceConfigs)
             {
-                var name = config.characterName;
+                var name = config.characterController.luaGlobalName;
                 nameToConfig[name] = config;
                 nameToEnabled[name] = false;
                 nameToIndex[name] = 0;

--- a/Assets/Nova/Sources/Scripts/Controllers/AvatarController.cs
+++ b/Assets/Nova/Sources/Scripts/Controllers/AvatarController.cs
@@ -9,7 +9,6 @@ namespace Nova
     [Serializable]
     public class AvatarConfig
     {
-        public string characterName;
         public GameCharacterController characterController;
         public string prefix;
     }
@@ -42,7 +41,7 @@ namespace Nova
             rectTransform = GetComponent<RectTransform>();
             foreach (var config in avatarConfigs)
             {
-                nameToConfig[config.characterName] = config;
+                nameToConfig[config.characterController.luaGlobalName] = config;
             }
 
             gameState.nodeChanged.AddListener(OnNodeChanged);

--- a/Assets/Resources/Scenarios/ch1.txt
+++ b/Assets/Resources/Scenarios/ch1.txt
@@ -4,7 +4,7 @@ is_unlocked_start()
 |>
 <|
 anim:trans_fade(cam, function()
-        show(ergong, 'normal', pos_c)
+        show(王二宫, 'normal', pos_c)
         show(bg, 'room')
     end, 2)
 play(bgm, 'prelude')
@@ -24,14 +24,14 @@ set_auto_voice_delay(2)
 秋天的雨似乎让她心情不佳。
 
 <|
-hide(ergong)
+hide(王二宫)
 |>
 大家坐在学生会室之中，都选择了沉默。
 
 耳畔只能听见淅淅沥沥的雨声枯燥地重复着。
 
 <|
-show(qianye, 'normal', pos_c)
+show(张浅野, 'normal', pos_c)
 sound('flap', 0.5)
 |>
 浅野学长靠在椅背上，像是无聊似的耸了耸肩。
@@ -41,14 +41,14 @@ sound('flap', 0.5)
 他是个有着一头白发的消瘦青年，在学生会里担任书记。
 
 <|
-hide(qianye)
+hide(张浅野)
 |>
 老师和校工今天都不会来，或许整个学校只剩下我们几个学生会干事。
 
 想到这一点，我不禁叹了口气。
 
 <|
-show(xiben, 'normal', pos_c)
+show(孙西本, 'normal', pos_c)
 |>
 孙西本：：“没有人带伞么？”
 
@@ -61,14 +61,14 @@ show(xiben, 'normal', pos_c)
 不过她若是多笑笑，想必能迷倒不少男生。
 
 <|
-hide(xiben)
+hide(孙西本)
 |>
 我是真心这样觉得的。
 
 西本成为学生会干事的理由是成绩突出，这也是我能坐在这里的原因。
 
 <|
-show(gaotian, 'normal', pos_c)
+show(陈高天, 'normal', pos_c)
 anim:fade_out(bgs, 2)
 |>
 陈高天：：“大家来得太匆忙了呀！”
@@ -78,14 +78,14 @@ anim:fade_out(bgs, 2)
 陈高天：：“突然通知我们要来，连原因也不说明。我早上买的奶茶都忘记喝了。”
 
 <|
-show(ergong, 'normal', pos_l)
-anim:move(gaotian, pos_r)
+show(王二宫, 'normal', pos_l)
+anim:move(陈高天, pos_r)
 |>
 王二宫：：“我也不想这样啊，都是浅野说那个文件送到了嘛。”
 
 <|
-hide(gaotian)
-show(qianye, 'normal', pos_r)
+hide(陈高天)
+show(张浅野, 'normal', pos_r)
 |>
 张浅野：：“结果还是因为暴雨延期了，这不是我的错。”
 
@@ -104,8 +104,8 @@ show(qianye, 'normal', pos_r)
 不过看着他们一直吵来吵去，旁人或许会觉得他们关系很好。
 
 <|
-hide(ergong)
-hide(qianye)
+hide(王二宫)
+hide(张浅野)
 anim:fade_out(bgm)
 |>
 我木然地看着两个人的互动。
@@ -113,7 +113,7 @@ anim:fade_out(bgm)
 这是学生会日常的一部分。
 
 <|
-show(gaotian, 'normal', pos_c)
+show(陈高天, 'normal', pos_c)
 play(bgm, 'gaotian')
 |>
 这时，高天从书包的侧面抽出了便利店之中常见的包装瓶。
@@ -145,14 +145,14 @@ play(bgm, 'gaotian')
 或许是她的心境受到了秋雨的影响，故而提出了这样的请求。
 
 <|
-hide(gaotian)
+hide(陈高天)
 |>
 学生会所有的人都看着我，他们对高天的过去都略知一二。
 
 我不可能拒绝。
 
 <|
-show(gaotian, 'normal')
+show(陈高天, 'normal')
 |>
 李竹内：：“好的。”
 
@@ -171,7 +171,7 @@ show(gaotian, 'normal')
 陈高天：：“对像我这样毫无特点的笨女孩也很体贴……”
 
 <|
-show(gaotian, 'cry')
+show(陈高天, 'cry')
 |>
 陈高天：：“果然竹内君接受我的告白，只是因为同情我吧。”
 
@@ -180,21 +180,21 @@ show(gaotian, 'cry')
 高天还是一个十分爱哭的女孩。
 
 <|
-hide(gaotian)
+hide(陈高天)
 |>
 我的身体僵硬。因为我察觉到，西本和会长在用尖锐的眼神瞪着我。
 
 幸好，这时浅野转移了话题。
 
 <|
-show(qianye, 'normal', pos_c)
+show(张浅野, 'normal', pos_c)
 |>
 张浅野：：“啊，对了，储物室有一次性的杯子。奶茶要是凉了呀……还是慢点喝为好。”
 
 浅野一边说着，一边对我摇了摇小指。
 
 <|
-hide(qianye)
+hide(张浅野)
 |>
 我心领神会。
 

--- a/Assets/Resources/Scenarios/ch2.txt
+++ b/Assets/Resources/Scenarios/ch2.txt
@@ -20,7 +20,7 @@ auto_voice_off('陈高天')
 洗手池的水龙头开着，花花的水声几乎要淹没我的声音。
 
 <|
-show(qianye, 'normal', pos_c, 0)
+show(张浅野, 'normal', pos_c, 0)
 anim:cam_punch()
 anim:vfx(cam, 'mono', {0, 0.9}, 0.3)
 sound('flap', 0.5)
@@ -81,8 +81,8 @@ sound('flap', 0.5)
 ？？？：：“哼，蠢货。”
 
 <|
-hide(qianye)
-tint(qianye, 1)
+hide(张浅野)
+tint(张浅野, 1)
 |>
 在我离开厕所的时候，那个人依旧对着我的背影骂着。
 

--- a/Assets/Resources/Scenarios/ch3.txt
+++ b/Assets/Resources/Scenarios/ch3.txt
@@ -22,7 +22,7 @@ v_flag_xiben = true
 回想起来，那段时光或许是我人生里最快乐的日子。
 
 <|
-show(xiben, 'normal', pos_r)
+show(孙西本, 'normal', pos_r)
 play(bgm, 'xiben')
 |>
 我看了看走廊，果然孙西本也在。
@@ -88,7 +88,7 @@ anim:move(cam, {3, 1.5, 3})
 李竹内：：“是的，西本同学。”
 
 <|
-hide(xiben)
+hide(孙西本)
 sound('clap')
 |>
 孙西本：：“你混蛋！”

--- a/Assets/Resources/Scenarios/ch4.txt
+++ b/Assets/Resources/Scenarios/ch4.txt
@@ -3,7 +3,7 @@ label('ch4', '终章')
 |>
 <|
 anim:trans_fade(cam, function()
-        show(ergong, 'normal', pos_c)
+        show(王二宫, 'normal', pos_c)
         show(bg, 'room')
     end)
 play(bgm, 'prelude')
@@ -23,7 +23,7 @@ set_auto_voice_delay(1)
 我推了推我的墨镜。会长勉强接受了这个借口。
 
 <|
-hide(ergong)
+hide(王二宫)
 |>
 我将杯子放到桌上，然后慢慢地倒出了奶茶。
 
@@ -32,13 +32,13 @@ hide(ergong)
 但是杯子总有装满的时候。
 
 <|
-show(gaotian, 'normal', pos_l)
+show(陈高天, 'normal', pos_l)
 |>
 高天看上去很高兴，我对她回以僵硬的笑。
 
 <|
-hide(gaotian)
-show(qianye, 'normal', pos_r)
+hide(陈高天)
+show(张浅野, 'normal', pos_r)
 |>
 这时，我的余光看到浅野的脸色一变。
 
@@ -52,8 +52,8 @@ branch {
 
 @<| label 'l_true' |>
 <|
-hide(qianye)
-show(xiben, 'normal', pos_r)
+hide(张浅野)
+show(孙西本, 'normal', pos_r)
 |>
 孙西本：：“我也要喝。”
 
@@ -62,19 +62,19 @@ show(xiben, 'normal', pos_r)
 她弯下腰的时候，头发上的缎带擦过我的鼻翼。
 
 <|
-show(gaotian, 'normal', pos_l)
+show(陈高天, 'normal', pos_l)
 |>
 陈高天：：“……西本同学……”
 
 高天露出了不知所措的表情，看上去像是受伤的小鹿。
 
 <|
-hide(gaotian)
+hide(陈高天)
 |>
 西本的手一顿，但是她装作没看见，依旧将奶茶往杯子里倒。
 
 <|
-show(ergong, 'normal', pos_l)
+show(王二宫, 'normal', pos_l)
 |>
 西本在这个高中一直不和他人有所接触，她的异状引起了会长的警觉。
 
@@ -87,8 +87,8 @@ show(ergong, 'normal', pos_l)
 王二宫：：“说不定西本同学也有些口渴呢。”
 
 <|
-hide(xiben)
-show(qianye, 'normal', pos_r)
+hide(孙西本)
+show(张浅野, 'normal', pos_r)
 |>
 张浅野：：“但、但是……竹内和高天不是……”
 
@@ -101,44 +101,44 @@ show(qianye, 'normal', pos_r)
 浅野偷偷扫了一眼被我扔到垃圾堆的空玻璃瓶，露出了绝望的表情。
 
 <|
-hide(qianye)
+hide(张浅野)
 |>
 王二宫：：“竹内君，不如你先请吧。大家一起喝，高天同学和西本同学也没意见吧？”
 
 <|
-hide(ergong)
+hide(王二宫)
 anim:fade_out(bgm)
 |>
 有意见。
 
 <|
-show(gaotian, 'cry', pos_l)
+show(陈高天, 'cry', pos_l)
 |>
 高天何止有意见，她的眼泪都要涌出来了。
 
 但是太过着急的她却无法将自己的意思表达出来。
 
 <|
-hide(gaotian)
-show(xiben, 'normal', pos_r)
+hide(陈高天)
+show(孙西本, 'normal', pos_r)
 |>
 西本呆立着，好像丢了魂。
 
 <|
-hide(xiben)
-show(ergong, 'normal', pos_l)
+hide(孙西本)
+show(王二宫, 'normal', pos_l)
 |>
 学生会长笑着看着我，她似乎猜到了什么。
 
 <|
-hide(ergong)
-show(qianye, 'normal', pos_r)
+hide(王二宫)
+show(张浅野, 'normal', pos_r)
 |>
 浅野也看着我。
 
 <|
 anim_hold_begin()
-hide(qianye)
+hide(张浅野)
 play(bgm, 'final', 0.1)
 anim_hold:volume(bgm, 0.5, 6.4)
 |>

--- a/Assets/Resources/Scenarios/test_many_chara.txt
+++ b/Assets/Resources/Scenarios/test_many_chara.txt
@@ -9,27 +9,27 @@ set_box()
 测试很多角色
 
 <|
-show(ergong, 'normal', {-6, 0, 0.5})
+show(王二宫, 'normal', {-6, 0, 0.5})
 |>
 111
 
 <|
-show(qianye, 'normal', {-2, 0, 0.5})
+show(张浅野, 'normal', {-2, 0, 0.5})
 |>
 222
 
 <|
-show(xiben, 'normal', {2, 0, 0.5})
+show(孙西本, 'normal', {2, 0, 0.5})
 |>
 333
 
 <|
-show(gaotian, 'normal', {6, 0, 0.5})
+show(陈高天, 'normal', {6, 0, 0.5})
 |>
 444
 
 <|
-show(gaotian, 'cry')
+show(陈高天, 'cry')
 |>
 555
 

--- a/Assets/Resources/Scenarios/test_transition.txt
+++ b/Assets/Resources/Scenarios/test_transition.txt
@@ -3,7 +3,7 @@ label 'test_transition'
 is_debug()
 |>
 <|
-show(xiben, 'normal', pos_l)
+show(孙西本, 'normal', pos_l)
 show(bg, 'room')
 set_box()
 |>
@@ -11,8 +11,8 @@ set_box()
 
 <|
 anim:trans(cam, function()
-        hide(xiben)
-        show(gaotian, 'normal', pos_r)
+        hide(孙西本)
+        show(陈高天, 'normal', pos_r)
         show(bg, 'corridor')
     end, 'fade', 1, { _Mask = 'Masks/eye' })
 |>
@@ -21,8 +21,8 @@ anim:trans(cam, function()
 
 <|
 anim:trans2(cam, function()
-        hide(gaotian)
-        show(xiben, 'normal', pos_l)
+        hide(陈高天)
+        show(孙西本, 'normal', pos_l)
         show(bg, 'room')
     end, 'broken_tv', 1)
 |>
@@ -39,9 +39,9 @@ anim:vfx(cam, 'color', {0, 1}, 1, { _ColorMul = 0 })
 -- 不在trans里的时候，角色的show和hide默认有零点几秒的淡入淡出动画
 -- 现在我们不需要这个动画，就要用auto_fade_off()和auto_fade_on()
 auto_fade_off()
-hide(xiben)
-show(gaotian, 'normal', pos_r)
-show(xiben, 'normal', pos_l)
+hide(孙西本)
+show(陈高天, 'normal', pos_r)
+show(孙西本, 'normal', pos_l)
 show(bg, 'corridor')
 auto_fade_on()
 anim:vfx(cam, 'color', {1, 0}, 1, { _ColorMul = 0 })
@@ -61,14 +61,14 @@ anim:vfx(bg, 'mix_add', {1, 0}, 1, { _Mask = 'Masks/vertical' })
 背景特效结束
 
 <|
-anim:vfx(gaotian, 'lens_blur', {0, 1}, 1, { _Size = 4 })
+anim:vfx(陈高天, 'lens_blur', {0, 1}, 1, { _Size = 4 })
 |>
 给立绘加特效
 
 立绘特效持续
 
 <|
-anim:vfx(gaotian, 'lens_blur', {1, 0}, 1, { _Size = 4 })
+anim:vfx(陈高天, 'lens_blur', {1, 0}, 1, { _Size = 4 })
 |>
 立绘特效结束
 
@@ -85,12 +85,12 @@ anim:vfx(cam, 'lens_blur', {1, 0}, 1, { _Size = 4 })
 摄像机特效结束
 
 <|
--- 先把gaotian和fg的layer设为cam2的layer，再给cam_mask加vfx
-gaotian.layer = cam2_overlay
+-- 先把陈高天和fg的layer设为cam2的layer，再给cam_mask加vfx
+陈高天.layer = cam2_overlay
 fg.layer = cam2_layer
-show(xiben, 'normal', pos_l)
+show(孙西本, 'normal', pos_l)
 show(bg, 'room')
-show(gaotian, 'normal', pos_r)
+show(陈高天, 'normal', pos_r)
 show(fg, 'moon_halo')
 cam2.cameraEnabled = true
 anim:vfx(cam_mask, 'fade', {0, 0.5}, 1, { _SubTex = 'RenderTargets/GameCamera2Texture', _Mask = 'Masks/wipe_left', _Vague = 0.1 })
@@ -118,8 +118,8 @@ anim:vfx(cam2, 'broken_tv', {0.5, 0}, 1)
 摄像机2特效结束
 
 <|
--- 把gaotian和fg的layer重置为cam1的layer，并把cam2的cullingMask设为cam1的cullingMask
-gaotian.layer = cam1_overlay
+-- 把陈高天和fg的layer重置为cam1的layer，并把cam2的cullingMask设为cam1的cullingMask
+陈高天.layer = cam1_overlay
 fg.layer = cam1_layer
 cam2.cullingMask = (2^cam1_layer) + (2^cam1_overlay)
 hide(fg)

--- a/Assets/Resources/Scenarios/test_video.txt
+++ b/Assets/Resources/Scenarios/test_video.txt
@@ -3,7 +3,7 @@ label 'test_video'
 is_debug()
 |>
 <|
-show(xiben, 'normal', pos_c)
+show(孙西本, 'normal', pos_c)
 show(bg, 'room')
 set_box()
 |>

--- a/Assets/Resources/Scenarios/tut02.txt
+++ b/Assets/Resources/Scenarios/tut02.txt
@@ -145,7 +145,7 @@ show(bg, 'room', {0, 0}, 1)
 好了，把背景恢复正常
 
 <|
-show(gaotian, 'normal', {0, -0.3, 0.4})
+show(陈高天, 'normal', {0, -0.3, 0.4})
 |>
 `show`也可以显示角色立绘，`gaotian`对应的就是Hierarchy里的`Characters/Gaotian`
 
@@ -156,55 +156,55 @@ show(gaotian, 'normal', {0, -0.3, 0.4})
 顺便说一句：：把立绘素材导入到Nova的方法详见[Wiki：立绘导入](https://github.com/Lunatic-Works/Nova/wiki/Standing-Import)
 
 <|
-show(gaotian, 'cry')
+show(陈高天, 'cry')
 |>
 改变一下立绘的表情
 
 <|
-show(gaotian, 'body+mouth_smile+eye_normal+eyebrow_normal+hair')
+show(陈高天, 'body+mouth_smile+eye_normal+eyebrow_normal+hair')
 |>
 也可以把pose字符串直接写在`show`里，调试完之后再写到`pose.lua`中
 
 <|
-show(gaotian, 'cry')
+show(陈高天, 'cry')
 |>
 立绘改变的时候默认有零点几秒的淡入淡出
 
 <|
-show(gaotian, 'normal')
+show(陈高天, 'normal')
 |>
 顺便说一句：：教程5会讲更复杂的动画
 
 <|
-move(gaotian, {-4, nil})
+move(陈高天, {-4, nil})
 |>
 `move`也可以移动立绘
 
 <|
-move(gaotian, pos_r)
+move(陈高天, pos_r)
 |>
 可以把`move`用到的坐标定义成一个变量`pos_r`，避免把同一个坐标输很多遍。这样的变量一般在`animation_presets.lua`中定义
 
 <|
-tint(gaotian, {0.5, 1, 0.5})
+tint(陈高天, {0.5, 1, 0.5})
 |>
 `tint`也可以改变立绘的颜色
 
 <|
-env_tint(gaotian, color_sunset)
-tint(gaotian, 1)
+env_tint(陈高天, color_sunset)
+tint(陈高天, 1)
 |>
 还有一个函数`env_tint`，也用来改变立绘的颜色（不能用在普通图片上面）。这里的`color_sunset`也是定义在`animation_presets.lua`中的变量
 
 <|
-tint(gaotian, 0.5)
+tint(陈高天, 0.5)
 |>
 `env_tint`与`tint`的效果可以叠加。`env_tint`一般用于黄昏、夜晚等环境引起的长时间的颜色变化，`tint`则用于短时间的演出效果
 
 <|
-move(gaotian, pos_c)
-env_tint(gaotian, 1)
-tint(gaotian, 1)
+move(陈高天, pos_c)
+env_tint(陈高天, 1)
+tint(陈高天, 1)
 |>
 好了，恢复立绘的位置和颜色
 
@@ -230,7 +230,7 @@ move(cam, {0, 0, 5})
 恢复摄像机位置
 
 <|
-hide(gaotian)
+hide(陈高天)
 |>
 教程2 图像 到此结束
 @<| jump_to 'tut03' |>

--- a/Assets/Resources/Scenarios/tut03.txt
+++ b/Assets/Resources/Scenarios/tut03.txt
@@ -42,7 +42,7 @@ stop(bgs)
 顺便说一句：：标题界面已经有背景音乐了，所以这些教程的开头都有`stop(bgm)`
 
 <|
-show(xiben, 'normal', pos_c)
+show(孙西本, 'normal', pos_c)
 sound('clap')
 |>
 `sound`函数用来播放音效
@@ -53,14 +53,14 @@ sound('clap', 0.5)
 `sound`的第二个参数是音量，默认为1（与`play`的音量默认值不同）
 
 <|
-say(xiben, '003007')
+say(孙西本, '003007')
 |>
 `say`函数用来播放语音
 
 顺便说一句：：Colorless的脚本中用到的都是自动语音，这个以后再讲
 
 <|
-hide(xiben)
+hide(孙西本)
 |>
 西本同学出来骂了你一顿之后又回去了
 

--- a/Assets/Resources/Scenarios/tut04.txt
+++ b/Assets/Resources/Scenarios/tut04.txt
@@ -111,14 +111,14 @@ set_box()
 顺便说一句：：为了方便写这些教程，我们还parse了Markdown的超链接和代码块，但是一般的游戏里应该不会用到吧
 
 <|
-show(xiben, 'normal', pos_c)
+show(孙西本, 'normal', pos_c)
 sound('clap')
 box_hide_show(2)
 |>
 `box_hide_show`用来让对话框消失几秒再出现，这个技巧可以把空间留给演出
 
 <|
-hide(xiben)
+hide(孙西本)
 stop_ff()
 |>
 `stop_ff`函数用来停止快进，`stop_auto_ff`则用来停止自动播放和快进

--- a/Assets/Resources/Scenarios/tut05.txt
+++ b/Assets/Resources/Scenarios/tut05.txt
@@ -9,13 +9,13 @@ set_box()
 教程5 动画
 
 <|
-show(gaotian, 'normal', pos_l)
-anim:move(gaotian, pos_r)
+show(陈高天, 'normal', pos_l)
+anim:move(陈高天, pos_r)
 |>
 `anim:move`函数用来创建移动动画
 
 <|
-move(gaotian, pos_l)
+move(陈高天, pos_l)
 |>
 如果没有`anim`，`move`就是瞬间完成的
 
@@ -24,7 +24,7 @@ move(gaotian, pos_l)
 顺便说一句：：具体可以看`animation.lua`和`animation_high_level.lua`
 
 <|
-anim:move(gaotian, pos_r, 2)
+anim:move(陈高天, pos_r, 2)
 |>
 `anim:move`的第三个参数是动画的时长，单位为秒，默认为1秒
 
@@ -35,56 +35,56 @@ anim:move(gaotian, pos_r, 2)
 移动动画的easing默认为`{0, 0}`，看起来会有比较自然的加减速。接下来举几个例子
 
 <|
-show(gaotian, 'normal', {-5, 3.5, 0.1})
-show(xiben, 'normal', {-5, 0.5, 0.1})
-anim:move(gaotian, {5}, 2, {0, 2})
-anim:move(xiben, {5}, 2, {1, 1})
+show(陈高天, 'normal', {-5, 3.5, 0.1})
+show(孙西本, 'normal', {-5, 0.5, 0.1})
+anim:move(陈高天, {5}, 2, {0, 2})
+anim:move(孙西本, {5}, 2, {1, 1})
 |>
 上面的小人先慢后快
 
 <|
-move(gaotian, {-5})
-move(xiben, {-5})
-anim:move(gaotian, {5}, 2, {2, 0})
-anim:move(xiben, {5}, 2, {1, 1})
+move(陈高天, {-5})
+move(孙西本, {-5})
+anim:move(陈高天, {5}, 2, {2, 0})
+anim:move(孙西本, {5}, 2, {1, 1})
 |>
 上面的小人先快后慢
 
 <|
-move(gaotian, {-5})
-move(xiben, {-5})
-anim:move(gaotian, {5}, 2, {0, -1})
-anim:move(xiben, {5}, 2, {1, 1})
+move(陈高天, {-5})
+move(孙西本, {-5})
+anim:move(陈高天, {5}, 2, {0, -1})
+anim:move(孙西本, {5}, 2, {1, 1})
 |>
 上面的小人跑出去一段再回来（结束时的速度为-1）
 
 顺便说一句：：上面这些非线性动画用的都是三次曲线，如果想用其他种类的曲线，可以把easing的第一个参数设为曲线的名字，这些名字在`animation_high_level.lua`中的`easing_func_name_map`里定义
 
 <|
-move(gaotian, {-5})
-move(xiben, {-5})
-anim:move(gaotian, {5}, 2, {'bezier', 0, 1})
-anim:move(xiben, {5}, 2, {1, 1})
+move(陈高天, {-5})
+move(孙西本, {-5})
+anim:move(陈高天, {5}, 2, {'bezier', 0, 1})
+anim:move(孙西本, {5}, 2, {1, 1})
 |>
 顺便说一句：：比如`bezier`可以做出更加夸张的加减速
 
 <|
-move(gaotian, {0})
-move(xiben, {-5})
-anim:move(gaotian, {5}, 2, {'shake', 20, 0.5})
-anim:move(xiben, {5}, 2, {1, 1})
+move(陈高天, {0})
+move(孙西本, {-5})
+anim:move(陈高天, {5}, 2, {'shake', 20, 0.5})
+anim:move(孙西本, {5}, 2, {1, 1})
 |>
 顺便说一句：：`shake`可以做出晃动，注意它最后不会停在`move`定义的目标位置，而是停在初始位置
 
 <|
-move(gaotian, pos_c)
-hide(xiben)
-anim:tint(gaotian, {0.5, 1, 0.5}, 2)
+move(陈高天, pos_c)
+hide(孙西本)
+anim:tint(陈高天, {0.5, 1, 0.5}, 2)
 |>
 `anim:tint`函数用来创建变色动画
 
 <|
-tint(gaotian, 1)
+tint(陈高天, 1)
 play(bgm, 'gaotian', 0)
 anim:volume(bgm, 0.5, 3)
 |>
@@ -101,15 +101,15 @@ anim:fade_out(bgm, 3)
 `anim:fade_out`函数则是淡出音乐
 
 <|
-anim:move(gaotian, pos_r):move(gaotian, pos_l)
+anim:move(陈高天, pos_r):move(陈高天, pos_l)
 |>
 在一段动画的后面继续用`move`等方法创建动画，就能把动画串联起来
 
 <|
-anim:move(gaotian, pos_r
-    ):_and():tint(gaotian, {0.5, 1, 0.5}
-    ):move(gaotian, pos_l
-    ):_and():tint(gaotian, 1)
+anim:move(陈高天, pos_r
+    ):_and():tint(陈高天, {0.5, 1, 0.5}
+    ):move(陈高天, pos_l
+    ):_and():tint(陈高天, 1)
 |>
 要让两段动画并行，可以用`_and()`函数
 
@@ -120,48 +120,48 @@ anim:move(gaotian, pos_r
 顺便说一句：：Lua不允许在冒号之前换行，所以用Lua写fluent interface的换行看起来很蛋疼。。
 
 <|
-show(xiben, 'normal', pos_r)
-local entry = anim:move(gaotian, pos_c)
-entry:move(gaotian, pos_l)
-entry:tint(gaotian, {0.5, 1, 0.5})
-entry:move(xiben, pos_c)
-entry:tint(xiben, {1, 0.5, 0.5})
+show(孙西本, 'normal', pos_r)
+local entry = anim:move(陈高天, pos_c)
+entry:move(陈高天, pos_l)
+entry:tint(陈高天, {0.5, 1, 0.5})
+entry:move(孙西本, pos_c)
+entry:tint(孙西本, {1, 0.5, 0.5})
 |>
 想要创建更复杂的树状结构，可以把一段动画的终点保存到一个局部变量里，再把这个变量作为多段动画的起点
 
 <|
-move(gaotian, pos_l)
-tint(gaotian, 1)
-hide(xiben)
-tint(xiben, 1)
-anim:move(gaotian, pos_r
+move(陈高天, pos_l)
+tint(陈高天, 1)
+hide(孙西本)
+tint(孙西本, 1)
+anim:move(陈高天, pos_r
     ):wait(1
-    ):move(gaotian, pos_l)
+    ):move(陈高天, pos_l)
 |>
 `anim:wait`函数用来延时，单位仍然是秒
 
 显示/隐藏角色、改变表情等操作是瞬间完成的，想要把它们放到动画里，就要用`anim:action`函数把它们转换成一段（时长为0的）动画
 
 <|
-anim:move(gaotian, pos_r
-    ):action(show, gaotian, 'cry'
-    ):move(gaotian, pos_l
-    ):action(hide, gaotian)
+anim:move(陈高天, pos_r
+    ):action(show, 陈高天, 'cry'
+    ):move(陈高天, pos_l
+    ):action(hide, 陈高天)
 |>
 `anim:action`的第一个参数是一个瞬间完成的函数，后面的参数则是那个函数的参数
 
 <|
-show(gaotian, 'normal', pos_l)
-anim:move(gaotian, pos_r
+show(陈高天, 'normal', pos_l)
+anim:move(陈高天, pos_r
     ):action(function()
-        show(gaotian, 'cry')
-        show(xiben, 'normal', pos_l)
+        show(陈高天, 'cry')
+        show(孙西本, 'normal', pos_l)
         sound('clap')
     end
-    ):move(gaotian, pos_l
+    ):move(陈高天, pos_l
     ):action(function()
-        show(gaotian, 'normal')
-        hide(xiben)
+        show(陈高天, 'normal')
+        hide(孙西本)
     end)
 |>
 也可以把`anim:action`的第一个参数设为一个匿名函数，里面可以写任何代码
@@ -169,7 +169,7 @@ anim:move(gaotian, pos_r
 顺便说一句：：虽然`action`里可以写任何代码，但是最好不要在`action`里创建新的动画，这个需求一般可以用动画的串行和并行来实现
 
 <|
-anim_hold:move(gaotian, pos_r, 10)
+anim_hold:move(陈高天, pos_r, 10)
 |>
 上面说的动画都是在一条对话之内的，如果想让动画跨越很多条对话，就要用`anim_hold`代替`anim`
 
@@ -185,15 +185,15 @@ anim_hold_end()
 持续动画结束之后要写`anim_hold_end()`
 
 <|
-show(gaotian, 'normal', pos_l)
-show(xiben, 'normal', pos_c)
+show(陈高天, 'normal', pos_l)
+show(孙西本, 'normal', pos_c)
 anim_hold:loop(function(entry)
-    return entry:move(gaotian, pos_c
-        ):move(gaotian, pos_l)
+    return entry:move(陈高天, pos_c
+        ):move(陈高天, pos_l)
 end)
 anim_hold:loop(function(entry)
-    return entry:move(xiben, pos_r, 1.414
-        ):move(xiben, pos_c, 1.414)
+    return entry:move(孙西本, pos_r, 1.414
+        ):move(孙西本, pos_c, 1.414)
 end)
 |>
 `anim_hold:loop`函数用来创建无限循环的动画
@@ -203,8 +203,8 @@ end)
 因为是无限循环，它只能作为持续动画，而不能作为对话内动画
 
 <|
-hide(gaotian)
-hide(xiben)
+hide(陈高天)
+hide(孙西本)
 anim_hold_end()
 |>
 教程5 动画 到此结束

--- a/Assets/Resources/Scenarios/tut06.txt
+++ b/Assets/Resources/Scenarios/tut06.txt
@@ -61,8 +61,8 @@ vfx(fg, 'screen_blink')
 大多数特效都有multiply和screen的版本
 
 <|
-show(gaotian, 'normal', pos_c)
-vfx(gaotian, 'lens_blur', 1, { _Size = 10 })
+show(陈高天, 'normal', pos_c)
+vfx(陈高天, 'lens_blur', 1, { _Size = 10 })
 hide(fg)
 move(fg, {0, 0, 1})
 vfx(fg, nil)
@@ -70,7 +70,7 @@ vfx(fg, nil)
 也可以对角色立绘添加特效
 
 <|
-vfx(gaotian, nil)
+vfx(陈高天, nil)
 vfx(cam, 'lens_blur', 1, { _Size = 10 })
 |>
 也可以对摄像机添加特效，这时立绘和背景一起被模糊了
@@ -129,8 +129,8 @@ anim:trans2(bg, 'room', 'color', 1, { _ColorAdd = 1 })
 
 <|
 anim:trans(cam, function()
-        hide(gaotian)
-        show(xiben, 'normal', pos_c)
+        hide(陈高天)
+        show(孙西本, 'normal', pos_c)
         show(bg, 'corridor')
     end, 'fade', 1, { _Mask = 'Masks/wipe_left' })
 |>
@@ -146,7 +146,7 @@ anim:trans_left(bg, 'room'):trans_right(bg, 'corridor')
 `animation_presets.lua`中定义了`trans_left`、`trans_right`等函数，就是把转场加上一些常用的参数
 
 <|
-hide(xiben)
+hide(孙西本)
 |>
 教程6 特效与转场 到此结束
 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1115,7 +1115,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7318139140313027263, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
       propertyPath: luaGlobalName
-      value: gaotian
+      value: "\u9648\u9AD8\u5929"
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
@@ -1406,7 +1406,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7318139140313027263, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
       propertyPath: luaGlobalName
-      value: qianye
+      value: "\u5F20\u6D45\u91CE"
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
@@ -1555,17 +1555,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   luaName: autoVoice
   autoVoiceConfigs:
-  - characterName: "\u738B\u4E8C\u5BAB"
-    characterController: {fileID: 319595391}
+  - characterController: {fileID: 319595391}
     prefix: 
-  - characterName: "\u5F20\u6D45\u91CE"
-    characterController: {fileID: 1952131526}
+  - characterController: {fileID: 1952131526}
     prefix: 
-  - characterName: "\u5B59\u897F\u672C"
-    characterController: {fileID: 2058258575}
+  - characterController: {fileID: 2058258575}
     prefix: 
-  - characterName: "\u9648\u9AD8\u5929"
-    characterController: {fileID: 1285618328}
+  - characterController: {fileID: 1285618328}
     prefix: 
   padWidth: 6
 --- !u!4 &880587543 stripped
@@ -1868,7 +1864,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7318139140313027263, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
       propertyPath: luaGlobalName
-      value: xiben
+      value: "\u5B59\u897F\u672C"
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
@@ -2218,7 +2214,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7318139140313027263, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
       propertyPath: luaGlobalName
-      value: ergong
+      value: "\u738B\u4E8C\u5BAB"
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d69e9accd9e3233469a7960c058dbb16, type: 3}
@@ -3974,6 +3970,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: GameView
       objectReference: {fileID: 0}
+    - target: {fileID: 2076122712185952433, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: avatarConfigs.Array.data[0].characterController
+      value: 
+      objectReference: {fileID: 319595391}
+    - target: {fileID: 2076122712185952433, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: avatarConfigs.Array.data[1].characterController
+      value: 
+      objectReference: {fileID: 1952131526}
+    - target: {fileID: 2076122712185952433, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: avatarConfigs.Array.data[2].characterController
+      value: 
+      objectReference: {fileID: 2058258575}
+    - target: {fileID: 2076122712185952433, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
+      propertyPath: avatarConfigs.Array.data[3].characterController
+      value: 
+      objectReference: {fileID: 1285618328}
     - target: {fileID: 2076122712400733067, guid: 3c27b5526c09db84e89cdd483dd6af66, type: 3}
       propertyPath: _sectors.Array.data[0].action.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 


### PR DESCRIPTION
以前Lua中的角色名称是Unity Editor中设置的`GameCharacterController.luaGlobalName`（一般为英文），而`AutoVoice`和`AvatarController`中的角色名称是脚本中写的`DialogueEntry.characterName`（一般为中文），中间用一个dict来转换

现在它们统一了，一般为中文

我们的Lua runtime应该支持中文变量名，脚本需要用UTF-8编码