### PR TITLE
存档系统重构，第一部分：`CheckpointSerializer`与`CheckpointManager`

### DIFF
--- a/Assets/Nova/Editor/SaveViewer.cs
+++ b/Assets/Nova/Editor/SaveViewer.cs
@@ -104,7 +104,7 @@ namespace Nova.Editor
                     var dialogue = -1;
                     while (dialogue < nodeRecord.lastCheckpointDialogue)
                     {
-                        dialogue = checkpointManager.GetCheckpointDialogue(offset);
+                        dialogue = checkpointManager.GetCheckpointDialogueIndex(offset);
                         var item = new TreeViewItem { id = rows.Count, displayName = $"checkpoint.{dialogue} @{offset}" };
                         rows.Add(offset);
                         root.AddChild(item);
@@ -221,7 +221,7 @@ namespace Nova.Editor
                 selectedCheckpoint.offset = selected;
                 if (selected >= 0)
                 {
-                    selectedCheckpoint.dialogueIndex = checkpointManager.GetCheckpointDialogue(selected);
+                    selectedCheckpoint.dialogueIndex = checkpointManager.GetCheckpointDialogueIndex(selected);
                     var checkpoint = checkpointManager.GetCheckpoint(selected);
                     selectedCheckpoint.checkpoint = checkpoint;
                     selectedCheckpoint.details.Clear();

--- a/Assets/Nova/Editor/SaveViewer.cs
+++ b/Assets/Nova/Editor/SaveViewer.cs
@@ -48,7 +48,7 @@ namespace Nova.Editor
             {
                 rows.Clear();
                 var root = new TreeViewItem { id = -1, depth = -1, displayName = "root" };
-                BuildTree(checkpointManager.beginNodeOffset, root);
+                BuildTree(checkpointManager.beginCheckpoint, root);
                 if (rows.Count == 0)
                 {
                     root.AddChild(new TreeViewItem { id = 0, displayName = "" });

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -499,11 +499,11 @@ namespace Nova
                 var voices = currentVoices.Count > 0 ? new Dictionary<string, VoiceEntry>(currentVoices) : null;
                 dialogueData = new ReachedDialogueData(currentNode.name, currentIndex, voices,
                     currentDialogueEntry.NeedInterpolate(), currentDialogueEntry.textHash);
-                checkpointManager.SetReached(dialogueData);
+                checkpointManager.SetReachedDialogue(dialogueData);
             }
             else
             {
-                dialogueData = checkpointManager.GetReachedDialogueData(currentNode.name, currentIndex);
+                dialogueData = checkpointManager.GetReachedDialogue(currentNode.name, currentIndex);
             }
 
             return dialogueData;

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -381,11 +381,10 @@ namespace Nova
                 checkpointEnsured = true;
             }
 
-            this.RuntimeAssert(currentIndex >= 0 && (currentNode.dialogueEntryCount == 0 ||
-                                                     currentIndex < currentNode.dialogueEntryCount),
-                               "Dialogue index out of range.");
             if (currentNode.dialogueEntryCount > 0)
             {
+                this.RuntimeAssert(currentIndex >= 0 && currentIndex < currentNode.dialogueEntryCount,
+                                   $"Dialogue index {currentIndex} out of range [0, {currentNode.dialogueEntryCount})");
                 currentDialogueEntry = currentNode.GetDialogueEntryAt(currentIndex);
                 ExecuteAction(UpdateDialogue(fromCheckpoint, nodeChanged));
             }

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -432,7 +432,7 @@ namespace Nova
 
         private void AppendSameNode()
         {
-            nodeRecord = checkpointManager.GetNextNode(nodeRecord, nodeRecord.name, variables, currentIndex);
+            nodeRecord = checkpointManager.GetNextNodeRecord(nodeRecord, nodeRecord.name, variables, currentIndex);
             checkpointOffset = nodeRecord.offset;
             checkpointEnsured = true;
             appendNodeEnsured = false;
@@ -505,7 +505,7 @@ namespace Nova
             // so the bookmark is left at the end of last node
             if (nextNode.dialogueEntryCount > 0)
             {
-                nodeRecord = checkpointManager.GetNextNode(nodeRecord, nextNode.name, variables, 0);
+                nodeRecord = checkpointManager.GetNextNodeRecord(nodeRecord, nextNode.name, variables, 0);
                 currentIndex = 0;
                 checkpointOffset = nodeRecord.offset;
             }

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -840,11 +840,11 @@ namespace Nova
             }
 
             newCheckpointOffset = checkpointManager.NextRecord(curNode.offset);
-            var checkpointDialogue = checkpointManager.GetCheckpointDialogue(newCheckpointOffset);
+            var checkpointDialogue = checkpointManager.GetCheckpointDialogueIndex(newCheckpointOffset);
             while (checkpointDialogue < curNode.lastCheckpointDialogue)
             {
                 var nextCheckpoint = checkpointManager.NextCheckpoint(newCheckpointOffset);
-                var nextCheckpointDialogue = checkpointManager.GetCheckpointDialogue(nextCheckpoint);
+                var nextCheckpointDialogue = checkpointManager.GetCheckpointDialogueIndex(nextCheckpoint);
                 if (nextCheckpointDialogue > newDialogueIndex)
                 {
                     break;
@@ -1065,7 +1065,7 @@ namespace Nova
             if (!foundHead)
             {
                 dialogue = entryNode.endDialogue - 1;
-                while (checkpointManager.GetCheckpointDialogue(offset) != entryNode.lastCheckpointDialogue)
+                while (checkpointManager.GetCheckpointDialogueIndex(offset) != entryNode.lastCheckpointDialogue)
                 {
                     offset = checkpointManager.NextCheckpoint(offset);
                 }
@@ -1139,7 +1139,7 @@ namespace Nova
                     curDialogue = curNode.beginDialogue;
                 }
 
-                var checkpointDialogue = checkpointManager.GetCheckpointDialogue(curCheckpoint);
+                var checkpointDialogue = checkpointManager.GetCheckpointDialogueIndex(curCheckpoint);
                 var endDialogue = i == 0 ? currentIndex : curNode.endDialogue;
                 while (curDialogue < endDialogue)
                 {
@@ -1148,7 +1148,7 @@ namespace Nova
                     if (checkpointDialogue < curNode.lastCheckpointDialogue)
                     {
                         nextCheckpoint = checkpointManager.NextCheckpoint(curCheckpoint);
-                        var nextCheckpointDialogue = checkpointManager.GetCheckpointDialogue(nextCheckpoint);
+                        var nextCheckpointDialogue = checkpointManager.GetCheckpointDialogueIndex(nextCheckpoint);
                         if (nextCheckpointDialogue < endDialogue)
                         {
                             curEndDialogue = nextCheckpointDialogue;

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -490,7 +490,7 @@ namespace Nova
                 case FlowChartNodeType.End:
                     state = State.Ended;
                     var endName = flowChartGraph.GetEndName(currentNode);
-                    checkpointManager.SetEndReached(endName);
+                    checkpointManager.SetReachedEnd(endName);
                     routeEnded.Invoke(new RouteEndedData(endName));
                     break;
                 default:

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -69,31 +69,32 @@ namespace Nova
             var success = false;
             try
             {
+                // Update globalSave.nodeHashes, flush and back up global save file
                 var needUpgrade = checkpointManager.CheckScriptUpgrade(flowChartGraph, out var changedNodes);
-                // Debug.Log($"upgrade {changedNodes.Count} nodes");
-                if (needUpgrade)
+                if (!needUpgrade)
                 {
-                    checkpointManager.UpdateGlobalSave();
-                    upgradeStarted = true;
-                    var upgrader = new CheckpointUpgrader(this, checkpointManager, changedNodes);
-                    upgrader.UpgradeSaves();
-                    success = true;
+                    return;
+                }
 
-                    if (updatePosition)
+                upgradeStarted = true;
+                var upgrader = new CheckpointUpgrader(this, checkpointManager, changedNodes);
+                upgrader.UpgradeSaves();
+                success = true;
+
+                if (updatePosition)
+                {
+                    if (upgrader.UpgradeBookmark(curPosition))
                     {
-                        if (upgrader.UpgradeBookmark(curPosition))
-                        {
-                            LoadBookmark(curPosition);
-                        }
-                        else if (currentNode != null)
-                        {
-                            // if we cannot update the current position, we start as if enter from the beginning of the node
-                            GameStart(currentNode.name);
-                        }
-                        else
-                        {
-                            Debug.LogError("Nova: Cannot reload script because the current node is deleted");
-                        }
+                        LoadBookmark(curPosition);
+                    }
+                    else if (currentNode != null)
+                    {
+                        // if we cannot update the current position, we start as if enter from the beginning of the node
+                        GameStart(currentNode.name);
+                    }
+                    else
+                    {
+                        Debug.LogError("Nova: Cannot reload script because the current node is deleted");
                     }
                 }
             }

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -62,7 +62,7 @@ namespace Nova
             Bookmark curPosition = null;
             if (updatePosition)
             {
-                curPosition = new Bookmark(nodeRecord, checkpointOffset, currentIndex);
+                curPosition = new Bookmark(nodeRecord.offset, checkpointOffset, currentIndex);
             }
 
             var upgradeStarted = false;
@@ -1176,7 +1176,7 @@ namespace Nova
                 throw new InvalidOperationException("Nova: Cannot save bookmark at this point.");
             }
 
-            return new Bookmark(nodeRecord, checkpointOffset, currentIndex);
+            return new Bookmark(nodeRecord.offset, checkpointOffset, currentIndex);
         }
 
         /// <summary>

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -48,18 +48,12 @@ namespace Nova
 
         private void Start()
         {
-            SaveInitialCheckpoint();
-            CheckScriptUpgrade(false);
-        }
-
-        // Called in Start after all restorables are initialized
-        private void SaveInitialCheckpoint()
-        {
-            // Save a clean state of game scene
             if (initialCheckpoint == null)
             {
                 initialCheckpoint = GetCheckpoint();
             }
+
+            CheckScriptUpgrade(false);
         }
 
         // It can run any Lua code, so everything that can be used in Lua code should initialize before Start
@@ -135,9 +129,6 @@ namespace Nova
 
         #region Start node
 
-        /// <summary>
-        /// Start the game from the given node
-        /// </summary>
         private void GameStart(FlowChartNode startNode)
         {
             ResetGameState();

--- a/Assets/Nova/Sources/Core/Restoration/Bookmark.cs
+++ b/Assets/Nova/Sources/Core/Restoration/Bookmark.cs
@@ -46,9 +46,9 @@ namespace Nova
 
         // NOTE: Do not use default parameters in constructor or it will fail to compile silently...
 
-        public Bookmark(NodeRecord nodeRecord, long checkpointOffset, int dialogueIndex)
+        public Bookmark(long nodeOffset, long checkpointOffset, int dialogueIndex)
         {
-            nodeOffset = nodeRecord.offset;
+            this.nodeOffset = nodeOffset;
             this.checkpointOffset = checkpointOffset;
             this.dialogueIndex = dialogueIndex;
         }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -345,32 +345,30 @@ namespace Nova
             var updateHashes = false;
             if (globalSave.nodeHashes != null)
             {
-                foreach (var node in flowChartGraph)
+                foreach (var nodeName in globalSave.nodeHashes.Keys)
                 {
-                    if (globalSave.nodeHashes.ContainsKey(node.name) &&
-                        globalSave.nodeHashes[node.name] != node.textHash &&
-                        reachedDialogues.TryGetValue(node.name, out var dialogue))
+                    if (flowChartGraph.HasNode(nodeName))
                     {
-                        updateHashes = true;
-                        ScriptLoader.AddDeferredDialogueChunks(node);
-                        var differ = new Differ(
-                            node.GetAllDialogues().Select(x => x.textHash).ToArray(),
-                            dialogue.Select(x => x.textHash).ToArray()
-                        );
-                        differ.GetDiffs();
-
-                        Debug.Log($"Nova: Node {node.name} needs upgrade.");
-                        changedNodes.Add(node.name, differ);
+                        var node = flowChartGraph.GetNode(nodeName);
+                        if (globalSave.nodeHashes[node.name] != node.textHash &&
+                            reachedDialogues.TryGetValue(node.name, out var dialogue))
+                        {
+                            updateHashes = true;
+                            ScriptLoader.AddDeferredDialogueChunks(node);
+                            var differ = new Differ(
+                                node.GetAllDialogues().Select(x => x.textHash).ToArray(),
+                                dialogue.Select(x => x.textHash).ToArray()
+                            );
+                            differ.GetDiffs();
+                            Debug.Log($"Nova: Node {node.name} needs upgrade.");
+                            changedNodes.Add(node.name, differ);
+                        }
                     }
-                }
-
-                foreach (var node in globalSave.nodeHashes.Keys)
-                {
-                    if (!flowChartGraph.HasNode(node))
+                    else
                     {
                         updateHashes = true;
-                        Debug.Log($"Nova: Node {node} needs delete.");
-                        changedNodes.Add(node, null);
+                        Debug.Log($"Nova: Node {nodeName} needs delete.");
+                        changedNodes.Add(nodeName, null);
                     }
                 }
             }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -238,28 +238,30 @@ namespace Nova
             return NextRecord(NextRecord(offset));
         }
 
+        // Get or create the next node record
         public NodeRecord GetNextNodeRecord(NodeRecord prevRecord, string name, Variables variables, int beginDialogue)
         {
             var variablesHash = variables.hash;
-            NodeRecord record = null;
+            NodeRecord childRecord = null;
             var offset = prevRecord?.child ?? globalSave.beginCheckpoint;
             while (offset != 0 && offset < globalSave.endCheckpoint)
             {
-                record = GetNodeRecord(offset);
-                if (record.name == name && record.variablesHash == variablesHash)
+                childRecord = GetNodeRecord(offset);
+                if (childRecord.name == name && childRecord.variablesHash == variablesHash)
                 {
-                    return record;
+                    return childRecord;
                 }
 
-                offset = record.sibling;
+                offset = childRecord.sibling;
             }
 
+            // Now childRecord is prevRecord's child's last sibling or null
             offset = globalSave.endCheckpoint;
             var newRecord = new NodeRecord(offset, name, beginDialogue, variablesHash);
-            if (record != null)
+            if (childRecord != null)
             {
-                record.sibling = offset;
-                UpdateNodeRecord(record);
+                childRecord.sibling = offset;
+                UpdateNodeRecord(childRecord);
             }
             else if (prevRecord != null)
             {

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -145,7 +145,7 @@ namespace Nova
             }
         }
 
-        private void NewReached()
+        private void UpdateEndReached()
         {
             globalSave.endReached = NextRecord(globalSave.endReached);
             globalSaveDirty = true;
@@ -162,7 +162,7 @@ namespace Nova
         private void AppendReachedRecord(IReachedData data)
         {
             serializer.SerializeRecord(globalSave.endReached, data);
-            NewReached();
+            UpdateEndReached();
         }
 
         public void SetReached(ReachedDialogueData data)
@@ -214,7 +214,7 @@ namespace Nova
 
         #region Checkpoint
 
-        public long beginNodeOffset
+        public long beginCheckpoint
         {
             get => globalSave.beginCheckpoint < globalSave.endCheckpoint ? globalSave.beginCheckpoint : 0;
             set
@@ -224,9 +224,9 @@ namespace Nova
             }
         }
 
-        public long endNodeOffset => globalSave.endCheckpoint;
+        public long endCheckpoint => globalSave.endCheckpoint;
 
-        private void NewCheckpointRecord()
+        private void UpdateEndCheckpoint()
         {
             globalSave.endCheckpoint = NextRecord(globalSave.endCheckpoint);
             globalSaveDirty = true;
@@ -238,7 +238,7 @@ namespace Nova
             return NextRecord(NextRecord(offset));
         }
 
-        public NodeRecord GetNextNode(NodeRecord prevRecord, string name, Variables variables, int beginDialogue)
+        public NodeRecord GetNextNodeRecord(NodeRecord prevRecord, string name, Variables variables, int beginDialogue)
         {
             var variablesHash = variables.hash;
             NodeRecord record = null;
@@ -273,7 +273,7 @@ namespace Nova
             }
 
             serializer.UpdateNodeRecord(newRecord);
-            NewCheckpointRecord();
+            UpdateEndCheckpoint();
             return newRecord;
         }
 
@@ -306,10 +306,10 @@ namespace Nova
             var buf = new ByteSegment(4);
             buf.WriteInt(0, dialogueIndex);
             serializer.AppendRecord(record, buf);
-            NewCheckpointRecord();
+            UpdateEndCheckpoint();
 
             serializer.SerializeRecord(globalSave.endCheckpoint, checkpoint);
-            NewCheckpointRecord();
+            UpdateEndCheckpoint();
             return record;
         }
 
@@ -385,7 +385,7 @@ namespace Nova
             nodeRecord.lastCheckpointDialogue = beginDialogue;
             nodeRecord.offset = globalSave.endCheckpoint;
             serializer.UpdateNodeRecord(nodeRecord);
-            NewCheckpointRecord();
+            UpdateEndCheckpoint();
 
             AppendCheckpoint(beginDialogue, beginCheckpoint);
             return nodeRecord.offset;

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -282,10 +282,10 @@ namespace Nova
             return serializer.GetNodeRecord(offset);
         }
 
-        public bool CanAppendCheckpoint(long checkpointOffset)
+        public bool CanAppendCheckpoint(long offset)
         {
-            return NextRecord(checkpointOffset) >= globalSave.endCheckpoint ||
-                   NextCheckpoint(checkpointOffset) >= globalSave.endCheckpoint;
+            return NextRecord(offset) >= globalSave.endCheckpoint ||
+                   NextCheckpoint(offset) >= globalSave.endCheckpoint;
         }
 
         public void AppendDialogue(NodeRecord nodeRecord, int dialogueIndex, bool shouldSaveCheckpoint)
@@ -301,19 +301,20 @@ namespace Nova
 
         public long AppendCheckpoint(int dialogueIndex, GameStateCheckpoint checkpoint)
         {
-            var record = globalSave.endCheckpoint;
+            var offset = globalSave.endCheckpoint;
 
             var buf = new ByteSegment(4);
             buf.WriteInt(0, dialogueIndex);
-            serializer.AppendRecord(record, buf);
+            serializer.AppendRecord(globalSave.endCheckpoint, buf);
             UpdateEndCheckpoint();
 
             serializer.SerializeRecord(globalSave.endCheckpoint, checkpoint);
             UpdateEndCheckpoint();
-            return record;
+
+            return offset;
         }
 
-        public int GetCheckpointDialogue(long offset)
+        public int GetCheckpointDialogueIndex(long offset)
         {
             return serializer.GetRecord(offset).ReadInt(0);
         }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -133,6 +133,10 @@ namespace Nova
                 {
                     reachedDialogues.Remove(maker.nodeName);
                 }
+                else
+                {
+                    Debug.LogWarning($"Nova: Unknown record type {record.GetType()} at offset {cur}");
+                }
             }
 
             // check each reached data is a prefix

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -353,7 +353,10 @@ namespace Nova
                     {
                         updateHashes = true;
                         ScriptLoader.AddDeferredDialogueChunks(node);
-                        var differ = new Differ(node, dialogue);
+                        var differ = new Differ(
+                            node.GetAllDialogues().Select(x => x.textHash).ToArray(),
+                            dialogue.Select(x => x.textHash).ToArray()
+                        );
                         differ.GetDiffs();
 
                         Debug.Log($"Nova: Node {node.name} needs upgrade.");

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -176,7 +176,7 @@ namespace Nova
             AppendReachedRecord(data);
         }
 
-        public void SetEndReached(string endName)
+        public void SetReachedEnd(string endName)
         {
             if (reachedEnds.Contains(endName))
             {
@@ -199,7 +199,7 @@ namespace Nova
             return reachedDialogues[nodeName][dialogueIndex];
         }
 
-        public bool IsEndReached(string endName)
+        public bool IsReachedEnd(string endName)
         {
             return reachedEnds.Contains(endName);
         }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -118,7 +118,7 @@ namespace Nova
         {
             reachedDialogues.Clear();
             reachedEnds.Clear();
-            for (var cur = globalSave.beginReached; cur < globalSave.endReached; cur = serializer.NextRecord(cur))
+            for (var cur = globalSave.beginReached; cur < globalSave.endReached; cur = NextRecord(cur))
             {
                 var record = serializer.DeserializeRecord<IReachedData>(cur);
                 if (record is ReachedEndData end)
@@ -147,7 +147,7 @@ namespace Nova
 
         private void NewReached()
         {
-            globalSave.endReached = serializer.NextRecord(globalSave.endReached);
+            globalSave.endReached = NextRecord(globalSave.endReached);
             globalSaveDirty = true;
             // Debug.Log($"next reached {globalSave.endReached}");
         }
@@ -228,7 +228,7 @@ namespace Nova
 
         private void NewCheckpointRecord()
         {
-            globalSave.endCheckpoint = serializer.NextRecord(globalSave.endCheckpoint);
+            globalSave.endCheckpoint = NextRecord(globalSave.endCheckpoint);
             globalSaveDirty = true;
             // Debug.Log($"next checkpoint {globalSave.endCheckpoint}");
         }
@@ -320,7 +320,7 @@ namespace Nova
 
         public GameStateCheckpoint GetCheckpoint(long offset)
         {
-            return serializer.DeserializeRecord<GameStateCheckpoint>(serializer.NextRecord(offset));
+            return serializer.DeserializeRecord<GameStateCheckpoint>(NextRecord(offset));
         }
 
         #endregion

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -351,13 +351,13 @@ namespace Nova
                     {
                         var node = flowChartGraph.GetNode(nodeName);
                         if (globalSave.nodeHashes[node.name] != node.textHash &&
-                            reachedDialogues.TryGetValue(node.name, out var dialogue))
+                            reachedDialogues.TryGetValue(node.name, out var dialogues))
                         {
                             updateHashes = true;
                             ScriptLoader.AddDeferredDialogueChunks(node);
                             var differ = new Differ(
                                 node.GetAllDialogues().Select(x => x.textHash).ToArray(),
-                                dialogue.Select(x => x.textHash).ToArray()
+                                dialogues.Select(x => x.textHash).ToArray()
                             );
                             differ.GetDiffs();
                             Debug.Log($"Nova: Node {node.name} needs upgrade.");
@@ -378,6 +378,7 @@ namespace Nova
                 globalSave.identifier = DateTime.Now.ToBinary();
                 globalSave.nodeHashes = flowChartGraph.ToDictionary(node => node.name, node => node.textHash);
                 globalSaveDirty = true;
+                UpdateGlobalSave();
             }
 
             return changedNodes.Any();

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
@@ -287,11 +287,6 @@ namespace Nova
             return new ByteSegment(buf);
         }
 
-        public NodeRecord GetNodeRecord(long offset)
-        {
-            return new NodeRecord(offset, GetRecord(offset));
-        }
-
         private CheckpointBlock AppendBlock()
         {
             var id = endBlock;
@@ -367,11 +362,6 @@ namespace Nova
                 segment = block.segment;
                 index = 0;
             }
-        }
-
-        public void UpdateNodeRecord(NodeRecord record)
-        {
-            AppendRecord(record.offset, record.ToByteSegment());
         }
 
         public void SerializeRecord<T>(long offset, T data, bool compress = DefaultCompress)

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
@@ -181,6 +181,9 @@ namespace Nova
         private long endBlock;
         private readonly LRUCache<long, CheckpointBlock> cachedBlocks;
         private readonly bool frozen;
+
+        // Hack: headerCorrupted is initialized to true,
+        // so UpdateFileHeader can run when the file is written for the first time
         private bool headerCorrupted = true;
 
         public CheckpointSerializer(string path, bool frozen)

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
@@ -332,6 +332,7 @@ namespace Nova
             return block.dataOffset + index;
         }
 
+        // Create or update a record at the given offset
         public void AppendRecord(long offset, ByteSegment bytes)
         {
             // Debug.Log($"append record @{offset} size={bytes.Count}");

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
@@ -313,12 +313,14 @@ namespace Nova
             return GetBlock(block.nextBlock);
         }
 
+        // Create a new linked list
         public long BeginRecord()
         {
             var block = AppendBlock();
             return block.dataOffset;
         }
 
+        // Get the offset of the next record in the same linked list
         public long NextRecord(long offset)
         {
             var block = GetBlockIndex(offset, out var index);

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
@@ -169,11 +169,11 @@ namespace Nova
 
         public static readonly byte[] FileHeader = Encoding.ASCII.GetBytes("NOVASAVE");
         private static readonly byte[] CorruptFileHeader = Enumerable.Repeat((byte)254, FileHeader.Length).ToArray();
-        public static readonly int FileHeaderSize = 4 + FileHeader.Length; // sizeof(int) + sizeof(FileHeader)
+        public static readonly int FileHeaderSize = FileHeader.Length + 4; // size of FileHeader + Version
         public static readonly int GlobalSaveOffset = FileHeaderSize + CheckpointBlock.HeaderSize;
 
         private const bool DefaultCompress = true;
-        private const int RecordHeader = 4; // sizeof(int)
+        private const int RecordHeader = 4; // sizeof(int), storing the size of the record
 
         private readonly JsonSerializer jsonSerializer;
         private readonly string path;
@@ -248,7 +248,6 @@ namespace Nova
         {
             var block = GetBlockIndex(offset, out var index);
             var segment = block.segment;
-
             if (segment.Count < index + RecordHeader)
             {
                 throw CheckpointCorruptedException.RecordOverflow(offset);
@@ -290,7 +289,8 @@ namespace Nova
 
         private CheckpointBlock AppendBlock()
         {
-            var id = endBlock++;
+            var id = endBlock;
+            ++endBlock;
             var block = new CheckpointBlock(file, id, OnBlockFlush);
             cachedBlocks[id] = block;
             return block;

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -155,7 +155,7 @@ namespace Nova
             long lastOffset = -1;
             while (true)
             {
-                var dialogue = checkpointManager.GetCheckpointDialogue(checkpointOffset);
+                var dialogue = checkpointManager.GetCheckpointDialogueIndex(checkpointOffset);
                 if (dialogue >= newNodeRecord.lastCheckpointDialogue)
                 {
                     bookmark.checkpointOffset = checkpointOffset;

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -177,7 +177,7 @@ namespace Nova
         {
             foreach (var nodeName in changedNodes.Keys)
             {
-                checkpointManager.InvalidateReachedData(nodeName);
+                checkpointManager.InvalidateReachedDialogues(nodeName);
             }
 
             var newRoot = UpgradeNodeTree(checkpointManager.beginCheckpoint);

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -180,8 +180,8 @@ namespace Nova
                 checkpointManager.InvalidateReachedData(nodeName);
             }
 
-            var newRoot = UpgradeNodeTree(checkpointManager.beginNodeOffset);
-            checkpointManager.beginNodeOffset = newRoot == 0 ? checkpointManager.endNodeOffset : newRoot;
+            var newRoot = UpgradeNodeTree(checkpointManager.beginCheckpoint);
+            checkpointManager.beginCheckpoint = newRoot == 0 ? checkpointManager.endCheckpoint : newRoot;
             Debug.Log("Nova: Upgrade bookmarks");
             foreach (var id in checkpointManager.bookmarksMetadata.Keys)
             {

--- a/Assets/Nova/Sources/Core/Restoration/Differ.cs
+++ b/Assets/Nova/Sources/Core/Restoration/Differ.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Nova
 {
@@ -46,10 +45,10 @@ namespace Nova
             return v[(d + 1) * d / 2 + (k + d) / 2];
         }
 
-        public Differ(FlowChartNode node, IEnumerable<ReachedDialogueData> reachedData)
+        public Differ(ulong[] scriptHashes, ulong[] saveHashes)
         {
-            scriptHashes = node.GetAllDialogues().Select(x => x.textHash).ToArray();
-            saveHashes = reachedData.Select(x => x.textHash).ToArray();
+            this.scriptHashes = scriptHashes;
+            this.saveHashes = saveHashes;
             distance = -1;
         }
 

--- a/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
@@ -467,7 +467,7 @@ namespace Nova
             var logEntryRestoreData = logEntriesRestoreData.FirstOrDefault();
             foreach (var pos in gameState.GetDialogueHistory(maxLogEntryNum))
             {
-                var dialogueData = checkpointManager.GetReachedDialogueData(pos.nodeRecord.name, pos.dialogueIndex);
+                var dialogueData = checkpointManager.GetReachedDialogue(pos.nodeRecord.name, pos.dialogueIndex);
                 DialogueDisplayData displayData = null;
 
                 if (logEntryRestoreData != null && logEntryRestoreData.index == logEntries.Count)


### PR DESCRIPTION
改动存档系统的时候需要特别小心，所以把这几个PR记在这里。这里的每个commit应该都可以单独拿出来检查。

主要增加了一个功能，在读取record时检查大小不超过`MaxRecordSize`。以前发生过一种情况，存档损坏之后不断allocate block，导致硬盘爆满，现在应该可以避免。

其他都是命名/顺序/注释的改动，不影响功能。