### PR TITLE
存档系统重构，第二部分：`GameState`

### DIFF
--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -171,7 +171,24 @@ namespace Nova
 
         public int currentIndex { get; private set; }
 
-        private DialogueEntry currentDialogueEntry => currentNode?.GetDialogueEntryAt(currentIndex);
+        private DialogueEntry currentDialogueEntry
+        {
+            get
+            {
+                var node = currentNode;
+                if (node == null)
+                {
+                    return null;
+                }
+
+                if (node.dialogueEntryCount == 0)
+                {
+                    return null;
+                }
+
+                return node.GetDialogueEntryAt(currentIndex);
+            }
+        }
 
         public DialogueDisplayData currentDialogueDisplayData => currentDialogueEntry?.GetDisplayData();
 

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -163,27 +163,15 @@ namespace Nova
 
         #region States
 
-        /// <summary>
-        /// The current node record in the global save file
-        /// </summary>
         private NodeRecord nodeRecord;
 
         private long checkpointOffset;
 
-        /// <summary>
-        /// The current flow chart node
-        /// </summary>
         public FlowChartNode currentNode { get; private set; }
 
-        /// <summary>
-        /// The index of the current dialogue entry in the current node
-        /// </summary>
         public int currentIndex { get; private set; }
 
-        /// <summary>
-        /// The current dialogueEntry
-        /// </summary>
-        private DialogueEntry currentDialogueEntry;
+        private DialogueEntry currentDialogueEntry => currentNode?.GetDialogueEntryAt(currentIndex);
 
         public DialogueDisplayData currentDialogueDisplayData => currentDialogueEntry?.GetDisplayData();
 
@@ -216,7 +204,6 @@ namespace Nova
             nodeRecord = null;
             currentNode = null;
             currentIndex = 0;
-            currentDialogueEntry = null;
             variables.Clear();
             state = State.Ended;
 
@@ -386,7 +373,6 @@ namespace Nova
             {
                 this.RuntimeAssert(currentIndex >= 0 && currentIndex < currentNode.dialogueEntryCount,
                                    $"Dialogue index {currentIndex} out of range [0, {currentNode.dialogueEntryCount})");
-                currentDialogueEntry = currentNode.GetDialogueEntryAt(currentIndex);
                 ExecuteAction(UpdateDialogue(fromCheckpoint, nodeChanged));
             }
             else
@@ -417,7 +403,7 @@ namespace Nova
             var isReachedAnyHistory = checkpointManager.IsReachedAnyHistory(currentNode.name, currentIndex);
             var dialogueData = DialogueSaveReachedData(isReachedAnyHistory);
             var dialogueChangedData = new DialogueChangedData(nodeRecord, checkpointOffset, dialogueData,
-                currentDialogueEntry.GetDisplayData(), isReached, isReachedAnyHistory);
+                currentDialogueDisplayData, isReached, isReachedAnyHistory);
             if (isJumping && !isReachedAnyHistory)
             {
                 isJumping = false;

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -876,7 +876,7 @@ namespace Nova
         }
 
         // If dialogueIndex >= newNodeRecord.endDialogue, then move to or create a new nodeRecord
-        private void Move(NodeRecord newNodeRecord, int dialogueIndex, bool upgrade)
+        public void Move(NodeRecord newNodeRecord, int dialogueIndex)
         {
             // Debug.Log($"Move begin {nodeRecord?.name} @{nodeRecord?.offset} {currentIndex} -> {newNodeRecord.name} @{newNodeRecord.offset} {dialogueIndex}");
 
@@ -890,7 +890,6 @@ namespace Nova
             nodeRecord = newNodeRecord;
 
             isRestoring = true;
-            isUpgrading = upgrade;
 
             // Find the last checkpoint before or at dialogueIndex
             var checkpointOffset = checkpointManager.NextRecord(nodeRecord.offset);
@@ -936,26 +935,22 @@ namespace Nova
             }
 
             isRestoring = false;
-            isUpgrading = false;
 
             // Debug.Log($"Move end {nodeRecord?.name} @{nodeRecord?.offset} {currentIndex} -> {newNodeRecord.name} @{newNodeRecord.offset} {dialogueIndex}");
         }
 
-        public void MoveBackTo(NodeRecord newNodeRecord, int dialogueIndex)
-        {
-            Move(newNodeRecord, dialogueIndex, false);
-        }
-
-        public void MoveToUpgrade(NodeRecord newNodeRecord, int lastDialogue)
+        public void MoveUpgrade(NodeRecord newNodeRecord, int lastDialogue)
         {
             state = State.Normal;
-            Move(newNodeRecord, lastDialogue, true);
+            isUpgrading = true;
+            Move(newNodeRecord, lastDialogue);
+            isUpgrading = false;
             // Move does not stop animations in the last step
             NovaAnimation.StopAll(AnimationType.All ^ AnimationType.UI);
             ResetGameState();
         }
 
-        public void MoveBackward()
+        public void StepBackward()
         {
             int newDialogueIndex;
             NodeRecord newNodeRecord;
@@ -980,7 +975,7 @@ namespace Nova
                 i++;
             }
 
-            MoveBackTo(newNodeRecord, newDialogueIndex);
+            Move(newNodeRecord, newDialogueIndex);
         }
 
         /// <summary>
@@ -1047,7 +1042,7 @@ namespace Nova
                 }
             }
 
-            MoveBackTo(entryNode, dialogue);
+            Move(entryNode, dialogue);
         }
 
         public void JumpToNextChapter()
@@ -1146,7 +1141,7 @@ namespace Nova
         public void LoadBookmark(Bookmark bookmark)
         {
             state = State.Normal;
-            MoveBackTo(checkpointManager.GetNodeRecord(bookmark.nodeOffset), bookmark.dialogueIndex);
+            Move(checkpointManager.GetNodeRecord(bookmark.nodeOffset), bookmark.dialogueIndex);
         }
 
         #endregion

--- a/Assets/Nova/Sources/Core/GameStateEvents.cs
+++ b/Assets/Nova/Sources/Core/GameStateEvents.cs
@@ -23,17 +23,15 @@ namespace Nova
     public class DialogueChangedData : GameStateEventData
     {
         public readonly NodeRecord nodeRecord;
-        public readonly long checkpointOffset;
         public readonly ReachedDialogueData dialogueData;
         public readonly DialogueDisplayData displayData;
         public readonly bool isReached;
         public readonly bool isReachedAnyHistory;
 
-        public DialogueChangedData(NodeRecord nodeRecord, long checkpointOffset, ReachedDialogueData dialogueData,
+        public DialogueChangedData(NodeRecord nodeRecord, ReachedDialogueData dialogueData,
             DialogueDisplayData displayData, bool isReached, bool isReachedAnyHistory)
         {
             this.nodeRecord = nodeRecord;
-            this.checkpointOffset = checkpointOffset;
             this.dialogueData = dialogueData;
             this.displayData = displayData;
             this.isReached = isReached;

--- a/Assets/Nova/Sources/Core/Restoration/Bookmark.cs
+++ b/Assets/Nova/Sources/Core/Restoration/Bookmark.cs
@@ -10,7 +10,6 @@ namespace Nova
         public const int ScreenshotHeight = 180;
 
         public long nodeOffset;
-        public long checkpointOffset;
         public int dialogueIndex;
         public DialogueDisplayData description;
         public readonly DateTime creationTime = DateTime.Now;
@@ -46,10 +45,9 @@ namespace Nova
 
         // NOTE: Do not use default parameters in constructor or it will fail to compile silently...
 
-        public Bookmark(long nodeOffset, long checkpointOffset, int dialogueIndex)
+        public Bookmark(long nodeOffset, int dialogueIndex)
         {
             this.nodeOffset = nodeOffset;
-            this.checkpointOffset = checkpointOffset;
             this.dialogueIndex = dialogueIndex;
         }
 

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -285,18 +285,15 @@ namespace Nova
 
         public NodeRecord GetNodeRecord(long offset)
         {
-            return new NodeRecord(offset, serializer.GetRecord(offset));
+            var record = new NodeRecord(offset, serializer.GetRecord(offset));
+            // Debug.Log($"GetNodeRecord {offset} {record.offset} {record.name} {record.beginDialogue} {record.endDialogue} {record.lastCheckpointDialogue}");
+            return record;
         }
 
         public void UpdateNodeRecord(NodeRecord record)
         {
+            // Debug.Log($"UpdateNodeRecord {record.offset} {record.name} {record.beginDialogue} {record.endDialogue} {record.lastCheckpointDialogue}");
             serializer.AppendRecord(record.offset, record.ToByteSegment());
-        }
-
-        public bool CanAppendCheckpoint(long offset)
-        {
-            return NextRecord(offset) >= globalSave.endCheckpoint ||
-                   NextCheckpoint(offset) >= globalSave.endCheckpoint;
         }
 
         public void AppendDialogue(NodeRecord nodeRecord, int dialogueIndex, bool shouldSaveCheckpoint)
@@ -310,10 +307,8 @@ namespace Nova
             UpdateNodeRecord(nodeRecord);
         }
 
-        public long AppendCheckpoint(int dialogueIndex, GameStateCheckpoint checkpoint)
+        public void AppendCheckpoint(int dialogueIndex, GameStateCheckpoint checkpoint)
         {
-            var offset = globalSave.endCheckpoint;
-
             var buf = new ByteSegment(4);
             buf.WriteInt(0, dialogueIndex);
             serializer.AppendRecord(globalSave.endCheckpoint, buf);
@@ -321,8 +316,6 @@ namespace Nova
 
             serializer.SerializeRecord(globalSave.endCheckpoint, checkpoint);
             UpdateEndCheckpoint();
-
-            return offset;
         }
 
         public int GetCheckpointDialogueIndex(long offset)

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointSerializer.cs
@@ -297,6 +297,24 @@ namespace Nova
             return new ByteSegment(buf);
         }
 
+        public int GetRecordSize(long offset)
+        {
+            var block = GetBlockIndex(offset, out var index);
+            var segment = block.segment;
+            if (index + RecordHeader > segment.Count)
+            {
+                throw CheckpointCorruptedException.RecordOverflow(offset);
+            }
+
+            var count = segment.ReadInt(index);
+            if (count <= 0 || count > MaxRecordSize)
+            {
+                throw CheckpointCorruptedException.InvalidRecordSize(offset, count);
+            }
+
+            return count;
+        }
+
         private CheckpointBlock AppendBlock()
         {
             var id = endBlock;

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -151,26 +151,7 @@ namespace Nova
 
             bookmark.nodeOffset = newOffset;
             bookmark.dialogueIndex = newDialogueIndex;
-            var checkpointOffset = checkpointManager.NextRecord(newOffset);
-            long lastOffset = -1;
-            while (true)
-            {
-                var dialogue = checkpointManager.GetCheckpointDialogueIndex(checkpointOffset);
-                if (dialogue >= newNodeRecord.lastCheckpointDialogue)
-                {
-                    bookmark.checkpointOffset = checkpointOffset;
-                    return true;
-                }
-
-                if (dialogue > newDialogueIndex)
-                {
-                    bookmark.checkpointOffset = lastOffset;
-                    return true;
-                }
-
-                lastOffset = checkpointOffset;
-                checkpointOffset = checkpointManager.NextCheckpoint(checkpointOffset);
-            }
+            return true;
         }
 
         public void UpgradeSaves()

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -76,7 +76,7 @@ namespace Nova
                     needResetParent = true;
                     // Debug.Log($"map nodeRecord @{offset} -> @{newOffset}");
                     nodeRecordMap.Add(offset, newOffset);
-                    gameState.MoveToUpgrade(nodeRecord, ed1);
+                    gameState.MoveUpgrade(nodeRecord, ed1);
                 }
                 else
                 {

--- a/Assets/Nova/Sources/Core/Restoration/ReachedData.cs
+++ b/Assets/Nova/Sources/Core/Restoration/ReachedData.cs
@@ -10,13 +10,11 @@ namespace Nova
     public readonly struct ReachedDialoguePosition
     {
         public readonly NodeRecord nodeRecord;
-        public readonly long checkpointOffset;
         public readonly int dialogueIndex;
 
-        public ReachedDialoguePosition(NodeRecord nodeRecord, long checkpointOffset, int dialogueIndex)
+        public ReachedDialoguePosition(NodeRecord nodeRecord, int dialogueIndex)
         {
             this.nodeRecord = nodeRecord;
-            this.checkpointOffset = checkpointOffset;
             this.dialogueIndex = dialogueIndex;
         }
     }

--- a/Assets/Nova/Sources/Scripts/DebugJumpHelper.cs
+++ b/Assets/Nova/Sources/Scripts/DebugJumpHelper.cs
@@ -4,7 +4,7 @@ namespace Nova
 {
     public class DebugJumpHelper : MonoBehaviour
     {
-        [SerializeField] private bool moveBackward;
+        [SerializeField] private bool stepBackward;
         [SerializeField] private bool previousChapter;
         [SerializeField] private bool nextChapter;
         [SerializeField] private bool previousBranch;
@@ -29,10 +29,10 @@ namespace Nova
                 return;
             }
 
-            if (moveBackward)
+            if (stepBackward)
             {
-                moveBackward = false;
-                MoveBackward();
+                stepBackward = false;
+                StepBackward();
             }
 
             if (previousChapter)
@@ -61,12 +61,12 @@ namespace Nova
             }
         }
 
-        private void MoveBackward()
+        private void StepBackward()
         {
             NovaAnimation.StopAll(AnimationType.All ^ AnimationType.UI);
             dialogueState.state = DialogueState.State.Normal;
 
-            gameState.MoveBackward();
+            gameState.StepBackward();
         }
     }
 }

--- a/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
@@ -309,7 +309,7 @@ namespace Nova
         public void MoveBackWithCallback(LogEntry logEntry, Action onFinish)
         {
             var nodeRecord = checkpointManager.GetNodeRecord(logEntry.nodeOffset);
-            gameState.MoveBackTo(nodeRecord, logEntry.dialogueData.dialogueIndex);
+            gameState.Move(nodeRecord, logEntry.dialogueData.dialogueIndex);
             this.Hide(onFinish);
         }
 

--- a/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
@@ -14,17 +14,15 @@ namespace Nova
         public float height;
         public float prefixHeight;
         public readonly long nodeOffset;
-        public readonly long checkpointOffset;
         public readonly ReachedDialogueData dialogueData;
         public readonly DialogueDisplayData displayData;
 
-        public LogEntry(float height, float prefixHeight, long nodeOffset, long checkpointOffset,
+        public LogEntry(float height, float prefixHeight, long nodeOffset,
             ReachedDialogueData dialogueData, DialogueDisplayData displayData)
         {
             this.height = height;
             this.prefixHeight = prefixHeight;
             this.nodeOffset = nodeOffset;
-            this.checkpointOffset = checkpointOffset;
             this.dialogueData = dialogueData;
             this.displayData = displayData;
         }
@@ -137,7 +135,7 @@ namespace Nova
 
             if (!gameState.isUpgrading)
             {
-                AddEntry(data.nodeRecord, data.checkpointOffset, data.dialogueData, data.displayData);
+                AddEntry(data.nodeRecord, data.dialogueData, data.displayData);
             }
         }
 
@@ -156,8 +154,7 @@ namespace Nova
             contentForTest.ForceRefresh();
         }
 
-        private void AddEntry(NodeRecord nodeRecord, long checkpointOffset, ReachedDialogueData dialogueData,
-            DialogueDisplayData displayData)
+        private void AddEntry(NodeRecord nodeRecord, ReachedDialogueData dialogueData, DialogueDisplayData displayData)
         {
             var text = displayData.FormatNameDialogue();
             if (string.IsNullOrEmpty(text))
@@ -169,8 +166,7 @@ namespace Nova
             var height = contentForTest.GetPreferredHeight(text, contentDefaultWidth);
             var cnt = logEntries.Count;
             var prefixHeight = height + (cnt > 0 ? logEntries[cnt - 1].prefixHeight : 0);
-            logEntries.Add(new LogEntry(height, prefixHeight, nodeRecord.offset, checkpointOffset, dialogueData,
-                displayData));
+            logEntries.Add(new LogEntry(height, prefixHeight, nodeRecord.offset, dialogueData, displayData));
 
             if (!RestrainLogEntryNum(maxLogEntryNum))
             {
@@ -313,7 +309,7 @@ namespace Nova
         public void MoveBackWithCallback(LogEntry logEntry, Action onFinish)
         {
             var nodeRecord = checkpointManager.GetNodeRecord(logEntry.nodeOffset);
-            gameState.MoveBackTo(nodeRecord, logEntry.checkpointOffset, logEntry.dialogueData.dialogueIndex);
+            gameState.MoveBackTo(nodeRecord, logEntry.dialogueData.dialogueIndex);
             this.Hide(onFinish);
         }
 
@@ -484,7 +480,7 @@ namespace Nova
                     displayData = entry.GetDisplayData();
                 }
 
-                AddEntry(pos.nodeRecord, pos.checkpointOffset, dialogueData, displayData);
+                AddEntry(pos.nodeRecord, dialogueData, displayData);
             }
         }
 


### PR DESCRIPTION
主要的更改是删除了`GameState.checkpointOffset`，并且把`currentDialogueEntry`等field改成getter-only property。这是为了减少独立的状态，并且减少leaky abstraction。现在“游戏状态”（不考虑全局变量）完全由`nodeRecord`（相当于节点历史）和`currentIndex`来确定。以前存档系统的一些bug就是因为`nodeRecord`更新之后`checkpointOffset`没有跟着更新。

每次存档时，从`nodeRecord`往后遍历来找到最新的`checkpointOffset`。一般一个node里的checkpoint不会超过100个，所以目前没有性能问题。需要`AppendSameNode`时，也是从`nodeRecord`往后遍历来判断它是不是全局存档文件里的最后一个node record。