### PR TITLE
存档系统重构，第三部分：`CheckpointUpgrader`

### DIFF
--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -84,7 +84,7 @@ namespace Nova
 
                 if (updatePosition)
                 {
-                    if (upgrader.UpgradeBookmark(curPosition))
+                    if (upgrader.TryUpgradeBookmark(curPosition))
                     {
                         LoadBookmark(curPosition);
                     }

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -78,6 +78,7 @@ namespace Nova
 
                 upgradeStarted = true;
                 var upgrader = new CheckpointUpgrader(this, checkpointManager, changedNodes);
+                // UpgradeSaves may reset nodeRecord and currentIndex
                 upgrader.UpgradeSaves();
                 success = true;
 
@@ -86,11 +87,6 @@ namespace Nova
                     if (upgrader.UpgradeBookmark(curPosition))
                     {
                         LoadBookmark(curPosition);
-                    }
-                    else if (currentNode != null)
-                    {
-                        // if we cannot update the current position, we start as if enter from the beginning of the node
-                        GameStart(currentNode);
                     }
                     else
                     {
@@ -122,7 +118,7 @@ namespace Nova
             scriptLoader.ForceInit(scriptPath);
             flowChartGraph = scriptLoader.GetFlowChartGraph();
             CheckScriptUpgrade(true);
-            Debug.Log("Nova: Reload complete.");
+            Debug.Log($"Nova: Reload complete {nodeRecord} {currentIndex}");
         }
 
         #endregion
@@ -479,7 +475,7 @@ namespace Nova
         {
             // var oldNodeRecord = nodeRecord;
             nodeRecord = checkpointManager.GetNextNodeRecord(nodeRecord, nodeRecord.name, variables, currentIndex);
-            // Debug.Log($"AppendSameNode {oldNodeRecord.name} @{oldNodeRecord.offset} -> {nodeRecord.name} @{nodeRecord.offset} {currentIndex}");
+            // Debug.Log($"AppendSameNode {oldNodeRecord} -> {nodeRecord}");
         }
 
         private ReachedDialogueData DialogueSaveReachedData(bool isReachedAnyHistory)

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -94,7 +94,7 @@ namespace Nova
                     }
                     else
                     {
-                        Debug.LogError("Nova: Cannot reload script because the current node is deleted");
+                        Debug.LogError("Nova: Cannot reload script because the current node is deleted.");
                     }
                 }
             }

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -862,6 +862,11 @@ namespace Nova
 
                 NovaAnimation.StopAll(AnimationType.PerDialogue | AnimationType.Text);
                 Step();
+                if (isUpgrading && i == stepCount - 1)
+                {
+                    NovaAnimation.StopAll(AnimationType.All ^ AnimationType.UI);
+                }
+
                 if (!fromMove && !isJumping)
                 {
                     return;
@@ -943,8 +948,6 @@ namespace Nova
             isUpgrading = true;
             Move(newNodeRecord, lastDialogue);
             isUpgrading = false;
-            // Move does not stop animations in the last step
-            NovaAnimation.StopAll(AnimationType.All ^ AnimationType.UI);
             ResetGameState();
         }
 

--- a/Assets/Nova/Sources/Core/GameState.cs
+++ b/Assets/Nova/Sources/Core/GameState.cs
@@ -377,7 +377,7 @@ namespace Nova
 
             if (nodeChanged)
             {
-                // Debug.Log($"Node changed to {nodeRecord.name}");
+                // Debug.Log($"Node changed to {nodeRecord}");
 
                 this.nodeChanged.Invoke(new NodeChangedData(nodeRecord.name));
 
@@ -821,7 +821,7 @@ namespace Nova
                 newDialogueIndex = endDialogue - steps;
             }
 
-            // Debug.Log($"newNode=@{nodeHistory[0].offset} newDialogueIndex={newDialogueIndex}");
+            // Debug.Log($"newNode @{nodeHistory[0].offset} newDialogueIndex {newDialogueIndex}");
             return totSteps;
         }
 
@@ -1151,6 +1151,6 @@ namespace Nova
 
         #endregion
 
-        // private string debugState => $"{currentNode?.name} {currentIndex} {variables.hash} | {stepsFromLastCheckpoint} {stepsCheckpointRestrained} {checkpointEnsured} {shouldSaveCheckpoint}";
+        // private string debugState => $"{nodeRecord?.name} {currentIndex} {variables.hash} | {stepsFromLastCheckpoint} {stepsCheckpointRestrained} {checkpointEnsured} {shouldSaveCheckpoint}";
     }
 }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -424,6 +424,7 @@ namespace Nova
             nodeRecord.offset = globalSave.endCheckpoint;
             UpdateNodeRecord(nodeRecord);
             UpdateEndCheckpoint();
+            ResetChildParent(nodeRecord);
 
             AppendCheckpoint(beginDialogue, checkpoint);
             return nodeRecord.offset;
@@ -441,14 +442,10 @@ namespace Nova
             }
         }
 
-        public void ResetChildParent(long offset)
-        {
-            ResetChildParent(GetNodeRecord(offset));
-        }
-
         public long DeleteNodeRecord(NodeRecord nodeRecord)
         {
             nodeRecord.offset = 0;
+            // Do not UpdateNodeRecord. The offset is only used in ResetChildParent
             ResetChildParent(nodeRecord);
             return nodeRecord.sibling;
         }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -415,8 +415,8 @@ namespace Nova
 
         public long UpgradeNodeRecord(NodeRecord nodeRecord, int beginDialogue)
         {
-            var beginCheckpoint = GetCheckpoint(NextRecord(nodeRecord.offset));
-            beginCheckpoint.dialogueIndex = beginDialogue;
+            var checkpoint = GetCheckpoint(NextRecord(nodeRecord.offset));
+            checkpoint.dialogueIndex = beginDialogue;
 
             nodeRecord.beginDialogue = beginDialogue;
             nodeRecord.endDialogue = beginDialogue + 1;
@@ -425,7 +425,7 @@ namespace Nova
             UpdateNodeRecord(nodeRecord);
             UpdateEndCheckpoint();
 
-            AppendCheckpoint(beginDialogue, beginCheckpoint);
+            AppendCheckpoint(beginDialogue, checkpoint);
             return nodeRecord.offset;
         }
 
@@ -451,20 +451,6 @@ namespace Nova
             nodeRecord.offset = 0;
             ResetChildParent(nodeRecord);
             return nodeRecord.sibling;
-        }
-
-        public bool IsNodeRecordTillEnd(NodeRecord nodeRecord)
-        {
-            if (nodeRecord.child != 0)
-            {
-                NodeRecord child = GetNodeRecord(nodeRecord.child);
-                if (child.name != nodeRecord.name)
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         #endregion

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -590,7 +590,14 @@ namespace Nova
                     return bookmark;
                 }
 
-                Destroy(old.screenshot);
+                if (bookmark != null && bookmark.screenshot == null)
+                {
+                    bookmark.screenshot = old.screenshot;
+                }
+                else
+                {
+                    Destroy(old.screenshot);
+                }
             }
 
             if (bookmark == null)
@@ -618,7 +625,7 @@ namespace Nova
 
             bookmark.globalSaveIdentifier = globalSave.identifier;
 
-            serializer.WriteBookmark(GetBookmarkFileName(saveID), isUpgrading ? bookmark : ReplaceCache(saveID, bookmark));
+            serializer.WriteBookmark(GetBookmarkFileName(saveID), ReplaceCache(saveID, bookmark));
             UpdateGlobalSave();
 
             var metadata = bookmarksMetadata.Ensure(saveID);
@@ -629,16 +636,16 @@ namespace Nova
             }
         }
 
-        public Bookmark LoadBookmark(int saveID, bool cache = true)
+        public Bookmark LoadBookmark(int saveID, bool isUpgrading = false)
         {
             var bookmark = serializer.ReadBookmark(GetBookmarkFileName(saveID));
-            if (cache && bookmark.globalSaveIdentifier != globalSave.identifier)
+            if (!isUpgrading && bookmark.globalSaveIdentifier != globalSave.identifier)
             {
                 Debug.LogWarning($"Nova: Save file is incompatible with the global save file. saveID: {saveID}");
                 bookmark = null;
             }
 
-            return cache ? ReplaceCache(saveID, bookmark) : bookmark;
+            return ReplaceCache(saveID, bookmark);
         }
 
         public void DeleteBookmark(int saveID)

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointManager.cs
@@ -406,7 +406,6 @@ namespace Nova
 
             if (updateHashes || globalSave.nodeHashes == null)
             {
-                globalSave.identifier = DateTime.Now.ToBinary();
                 globalSave.nodeHashes = flowChartGraph.ToDictionary(node => node.name, node => node.textHash);
                 globalSaveDirty = true;
                 UpdateGlobalSave();
@@ -544,6 +543,7 @@ namespace Nova
             globalSave = new GlobalSave(serializer);
             globalSaveDirty = true;
             InitReached();
+            Debug.Log("Nova: Global save reset.");
         }
 
         public void RestoreGlobalSave()
@@ -553,7 +553,11 @@ namespace Nova
             {
                 File.Copy(globalSaveBackupPath, globalSavePath, true);
                 TryInitGlobalSaveReached();
-                if (globalSave == null)
+                if (globalSave != null)
+                {
+                    Debug.Log("Nova: Global save restored.");
+                }
+                else
                 {
                     Debug.LogError("Nova: Failed to restore global save. Trying to reset...");
                     serializer.Dispose();
@@ -641,7 +645,9 @@ namespace Nova
             var bookmark = serializer.ReadBookmark(GetBookmarkFileName(saveID));
             if (!isUpgrading && bookmark.globalSaveIdentifier != globalSave.identifier)
             {
-                Debug.LogWarning($"Nova: Save file is incompatible with the global save file. saveID: {saveID}");
+                Debug.LogWarning(
+                    $"Nova: Bookmark {saveID} " +
+                    $"globalSaveIdentifier {bookmark.globalSaveIdentifier} != {globalSave.identifier}");
                 bookmark = null;
             }
 

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -100,6 +100,7 @@ namespace Nova
             return UpgradeBookmark(0, bookmark);
         }
 
+        // Returns whether the updated bookmark is valid
         private bool UpgradeBookmark(int key, Bookmark bookmark)
         {
             if (!nodeRecordMap.TryGetValue(bookmark.nodeOffset, out var newOffset))
@@ -119,7 +120,9 @@ namespace Nova
             if (newDialogueIndex < newNodeRecord.beginDialogue || newDialogueIndex >= newNodeRecord.endDialogue)
             {
                 Debug.LogWarning(
-                    $"Nova: Cannot upgrade bookmark {key} because dialogue {newDialogueIndex} is deleted.");
+                    $"Nova: Cannot upgrade bookmark {key} because dialogue {newDialogueIndex} is out of range " +
+                    $"[{newNodeRecord.beginDialogue}, {newNodeRecord.endDialogue})."
+                );
                 return false;
             }
 

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -115,13 +115,13 @@ namespace Nova
             }
         }
 
-        public bool UpgradeBookmark(Bookmark bookmark)
+        public bool TryUpgradeBookmark(Bookmark bookmark)
         {
-            return UpgradeBookmark(0, bookmark);
+            return TryUpgradeBookmark(0, bookmark);
         }
 
         // Returns whether the updated bookmark is valid
-        private bool UpgradeBookmark(int key, Bookmark bookmark)
+        private bool TryUpgradeBookmark(int key, Bookmark bookmark)
         {
             // Debug.Log($"Nova: Upgrade bookmark {key} @{bookmark.nodeOffset} {bookmark.dialogueIndex}");
 
@@ -176,9 +176,13 @@ namespace Nova
             foreach (var id in checkpointManager.bookmarksMetadata.Keys)
             {
                 var bookmark = checkpointManager.LoadBookmark(id, true);
-                if (UpgradeBookmark(id, bookmark))
+                if (TryUpgradeBookmark(id, bookmark))
                 {
                     checkpointManager.SaveBookmark(id, bookmark, true);
+                }
+                else
+                {
+                    checkpointManager.DeleteBookmark(id);
                 }
             }
         }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -173,15 +173,24 @@ namespace Nova
 
             var newRoot = UpgradeNodeTree(checkpointManager.beginCheckpoint);
             checkpointManager.beginCheckpoint = newRoot == 0 ? checkpointManager.endCheckpoint : newRoot;
+
             foreach (var id in checkpointManager.bookmarksMetadata.Keys)
             {
-                var bookmark = checkpointManager.LoadBookmark(id, true);
-                if (TryUpgradeBookmark(id, bookmark))
+                try
                 {
-                    checkpointManager.SaveBookmark(id, bookmark, true);
+                    var bookmark = checkpointManager.LoadBookmark(id, true);
+                    if (TryUpgradeBookmark(id, bookmark))
+                    {
+                        checkpointManager.SaveBookmark(id, bookmark, true);
+                    }
+                    else
+                    {
+                        checkpointManager.DeleteBookmark(id);
+                    }
                 }
-                else
+                catch (Exception e)
                 {
+                    Debug.LogError($"Nova: Failed to upgrade bookmark {id}: {e}");
                     checkpointManager.DeleteBookmark(id);
                 }
             }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -44,24 +45,43 @@ namespace Nova
                 var st0 = nodeRecord.beginDialogue;
                 var ed0 = nodeRecord.endDialogue;
 
-                // case 0: if this is the start of a node
-                // it must map beginDialogue to 0
-                var st1 = st0 == 0 ? 0 : differ.rightMap[st0];
-                // ed1 is the mapped endDialogue
-                var ed1 = differ.leftMap[ed0 - 1] + 1;
-                if (nodeRecord.child != 0)
+                int st1;
+                if (st0 <= 0 || differ.rightMap.Count == 0)
                 {
-                    var child = checkpointManager.GetNodeRecord(nodeRecord.child);
-                    // case 1: if it has a child of a different node
-                    // it must map endDialogue to the end of the node
-                    if (child.name != nodeRecord.name)
+                    // beginDialogue is at the beginning of the node,
+                    // then map it to the beginning of the upgraded node
+                    st1 = 0;
+                }
+                else
+                {
+                    st1 = differ.rightMap[Math.Min(st0, differ.rightMap.Count - 1)];
+                }
+
+                int ed1;
+                if (nodeRecord.child == 0)
+                {
+                    if (ed0 <= 0 || differ.leftMap.Count == 0)
                     {
-                        ed1 = differ.remap.Count;
+                        ed1 = 0;
                     }
-                    // case 2: if it has a child of the same node
-                    // it must map endDialogue to the last node of that node
                     else
                     {
+                        ed1 = differ.leftMap[Math.Min(ed0, differ.leftMap.Count) - 1] + 1;
+                    }
+                }
+                else
+                {
+                    var child = checkpointManager.GetNodeRecord(nodeRecord.child);
+                    if (child.name != nodeRecord.name)
+                    {
+                        // nodeRecord has a child of a different node,
+                        // then map endDialogue to the end of the upgraded nodeRecord
+                        ed1 = differ.remap.Count;
+                    }
+                    else
+                    {
+                        // nodeRecord has a child of the same node,
+                        // then map endDialogue to the beginning of that node
                         ed1 = child.beginDialogue;
                     }
                 }

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -30,7 +30,6 @@ namespace Nova
             nodeRecord.sibling = UpgradeNodeTree(nodeRecord.sibling);
 
             var newOffset = offset;
-            var needResetParent = false;
             if (changedNodes.TryGetValue(nodeRecord.name, out var differ))
             {
                 if (differ == null)
@@ -73,9 +72,12 @@ namespace Nova
                 if (st1 < ed1)
                 {
                     newOffset = checkpointManager.UpgradeNodeRecord(nodeRecord, st1);
-                    needResetParent = true;
                     // Debug.Log($"map nodeRecord @{offset} -> @{newOffset}");
                     nodeRecordMap.Add(offset, newOffset);
+                    // Now there must be a checkpoint at the first dialogue of the new node record,
+                    // which is copied from the old node record
+                    // We assume that this checkpoint is unchanged in the upgrade,
+                    // and create the next checkpoints in this node record by jumping forward
                     gameState.MoveUpgrade(nodeRecord, ed1 - 1);
                 }
                 else
@@ -111,11 +113,6 @@ namespace Nova
             {
                 // just save this record with new child and sibling
                 checkpointManager.UpdateNodeRecord(nodeRecord);
-            }
-
-            if (needResetParent)
-            {
-                checkpointManager.ResetChildParent(newOffset);
             }
 
             return newOffset;

--- a/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
+++ b/Assets/Nova/Sources/Core/Restoration/CheckpointUpgrader.cs
@@ -50,8 +50,8 @@ namespace Nova
                 // case 0: if this is the start of a node
                 // it must map beginDialogue to 0
                 var st1 = st0 == 0 ? 0 : differ.rightMap[st0];
-                // ed1 is the mapped endDialogue - 1
-                var ed1 = differ.leftMap[ed0 - 1];
+                // ed1 is the mapped endDialogue
+                var ed1 = differ.leftMap[ed0 - 1] + 1;
                 if (nodeRecord.child != 0)
                 {
                     var child = checkpointManager.GetNodeRecord(nodeRecord.child);
@@ -59,24 +59,24 @@ namespace Nova
                     // it must map endDialogue to the end of the node
                     if (child.name != nodeRecord.name)
                     {
-                        ed1 = differ.remap.Count - 1;
+                        ed1 = differ.remap.Count;
                     }
                     // case 2: if it has a child of the same node
                     // it must map endDialogue to the last node of that node
                     else
                     {
-                        ed1 = child.beginDialogue - 1;
+                        ed1 = child.beginDialogue;
                     }
                 }
 
-                // Debug.Log($"map nodeRecord @{offset} [{st0}, {ed0}) -> [{st1}, {ed1}]");
-                if (st1 <= ed1)
+                // Debug.Log($"map nodeRecord @{offset} [{st0}, {ed0}) -> [{st1}, {ed1})");
+                if (st1 < ed1)
                 {
                     newOffset = checkpointManager.UpgradeNodeRecord(nodeRecord, st1);
                     needResetParent = true;
                     // Debug.Log($"map nodeRecord @{offset} -> @{newOffset}");
                     nodeRecordMap.Add(offset, newOffset);
-                    gameState.MoveUpgrade(nodeRecord, ed1);
+                    gameState.MoveUpgrade(nodeRecord, ed1 - 1);
                 }
                 else
                 {

--- a/Assets/Nova/Sources/Core/Restoration/NodeRecord.cs
+++ b/Assets/Nova/Sources/Core/Restoration/NodeRecord.cs
@@ -59,7 +59,7 @@ namespace Nova
 
         public override string ToString()
         {
-            return $"{name} @{offset} [{beginDialogue},{endDialogue})";
+            return $"{name} @{offset} [{beginDialogue}, {endDialogue})";
         }
     }
 }

--- a/Assets/Nova/Sources/Core/Restoration/NodeRecord.cs
+++ b/Assets/Nova/Sources/Core/Restoration/NodeRecord.cs
@@ -56,5 +56,10 @@ namespace Nova
             variablesHash = segment.ReadUlong(36);
             name = segment.ReadString(HeaderSize);
         }
+
+        public override string ToString()
+        {
+            return $"{name} @{offset} [{beginDialogue},{endDialogue})";
+        }
     }
 }

--- a/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
+++ b/Assets/Nova/Sources/Scripts/UI/Views/LogController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.InputSystem;


### PR DESCRIPTION
主要的更改是把一个node record从child-sibling tree中删除时统一用`DeleteNodeRecord`来处理，以及在一个node record里的对话被删光时处理一些边界条件。另外还修复了在存档升级之后读取bookmark时的一些问题。

目前剩下的一个问题是，我们假设每个node record开头的一个checkpoint不变。事实上如果前面的node record变了，那它就有可能变。以后我们可以再写一个“大升级”，从前往后把所有node record推一遍。